### PR TITLE
GameManagerのコーディングを進めた。

### DIFF
--- a/CardGame/Assets/Scenes/Main.unity
+++ b/CardGame/Assets/Scenes/Main.unity
@@ -248,6 +248,284 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 10759520}
+--- !u!1 &72119792
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 72119793}
+  - component: {fileID: 72119797}
+  - component: {fileID: 72119796}
+  - component: {fileID: 72119795}
+  - component: {fileID: 72119794}
+  m_Layer: 5
+  m_Name: OKButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &72119793
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 72119792}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -8.299999, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_Children:
+  - {fileID: 1490103818}
+  m_Father: {fileID: 1752934217}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -8.3}
+  m_SizeDelta: {x: 320, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &72119794
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 72119792}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 359c7bbb3603ab243a9af0a113e94687, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  targetCanvas: {fileID: 1752934216}
+  CannotCanvas: {fileID: 1752934216}
+--- !u!114 &72119795
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 72119792}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 72119796}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 72119794}
+        m_MethodName: CannnotSkip
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &72119796
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 72119792}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &72119797
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 72119792}
+--- !u!1 &102522376
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 102522377}
+  - component: {fileID: 102522379}
+  - component: {fileID: 102522378}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &102522377
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 102522376}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1617951925}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &102522378
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 102522376}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 80
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 8
+    m_MaxSize: 80
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: No
+--- !u!222 &102522379
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 102522376}
+--- !u!1 &164596186
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 164596187}
+  - component: {fileID: 164596189}
+  - component: {fileID: 164596188}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &164596187
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 164596186}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2129794890}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &164596188
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 164596186}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.229}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &164596189
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 164596186}
 --- !u!1 &191372347
 GameObject:
   m_ObjectHideFlags: 0
@@ -320,34 +598,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &300998876
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 300998877}
-  m_Layer: 0
-  m_Name: Tomb
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &300998877
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 300998876}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1305146049}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &333579406
 GameObject:
@@ -427,7 +677,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 333579411}
-        m_MethodName: skip
+        m_MethodName: ShowSkipDialog
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -483,6 +733,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 359c7bbb3603ab243a9af0a113e94687, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  targetCanvas: {fileID: 2129794889}
+  CannotCanvas: {fileID: 1752934216}
 --- !u!1 &473651035
 GameObject:
   m_ObjectHideFlags: 0
@@ -631,6 +883,170 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 535391226}
+--- !u!1 &538741712
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 538741713}
+  - component: {fileID: 538741716}
+  - component: {fileID: 538741715}
+  - component: {fileID: 538741714}
+  - component: {fileID: 538741717}
+  m_Layer: 5
+  m_Name: YesButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &538741713
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 538741712}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -167, y: -8.299999, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_Children:
+  - {fileID: 1365377808}
+  m_Father: {fileID: 2129794890}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -167, y: -8.3}
+  m_SizeDelta: {x: 320, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &538741714
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 538741712}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 538741715}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 538741717}
+        m_MethodName: DoSkip
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &538741715
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 538741712}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &538741716
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 538741712}
+--- !u!114 &538741717
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 538741712}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 359c7bbb3603ab243a9af0a113e94687, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  targetCanvas: {fileID: 2129794889}
+  CannotCanvas: {fileID: 0}
+--- !u!1 &549655250
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 549655251}
+  m_Layer: 0
+  m_Name: Field
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &549655251
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 549655250}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1782534839}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &565398957
 GameObject:
   m_ObjectHideFlags: 0
@@ -801,6 +1217,74 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &671839308
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 671839309}
+  - component: {fileID: 671839311}
+  - component: {fileID: 671839310}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &671839309
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 671839308}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1752934217}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &671839310
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 671839308}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.229}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &671839311
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 671839308}
 --- !u!1 &1064959131
 GameObject:
   m_ObjectHideFlags: 0
@@ -934,6 +1418,120 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1139560944
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1139560945}
+  - component: {fileID: 1139560946}
+  m_Layer: 0
+  m_Name: Hand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1139560945
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1139560944}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1782534839}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1139560946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1139560944}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 650afc76ac6e0324992086b6617d53b6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1142189509
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1142189510}
+  - component: {fileID: 1142189512}
+  - component: {fileID: 1142189511}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1142189510
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1142189509}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 180, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_Children: []
+  m_Father: {fileID: 2129794890}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 180}
+  m_SizeDelta: {x: 1200, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1142189511
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1142189509}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 6b40e3a31d4bf1c4dac4997225fa5e48, type: 3}
+    m_FontSize: 80
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 80
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u30D5\u30A7\u30A4\u30BA\u3092\u30B9\u30AD\u30C3\u30D7\u3057\u307E\u3059\u304B\uFF1F"
+--- !u!222 &1142189512
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1142189509}
 --- !u!1 &1146495174
 GameObject:
   m_ObjectHideFlags: 0
@@ -1088,101 +1686,204 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2fe499a46950d2143a29644e0688e6ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &1285452355
+--- !u!1 &1284471623
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 1285452356}
-  - component: {fileID: 1285452357}
-  m_Layer: 0
-  m_Name: Hand
+  - component: {fileID: 1284471624}
+  - component: {fileID: 1284471626}
+  - component: {fileID: 1284471625}
+  m_Layer: 5
+  m_Name: Text
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1285452356
-Transform:
+--- !u!224 &1284471624
+RectTransform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1285452355}
+  m_GameObject: {fileID: 1284471623}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 0, y: 180, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_Children: []
-  m_Father: {fileID: 1305146049}
-  m_RootOrder: 1
+  m_Father: {fileID: 1752934217}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1285452357
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 180}
+  m_SizeDelta: {x: 1200, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1284471625
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1285452355}
+  m_GameObject: {fileID: 1284471623}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 650afc76ac6e0324992086b6617d53b6, type: 3}
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &1305146048
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 6b40e3a31d4bf1c4dac4997225fa5e48, type: 3}
+    m_FontSize: 80
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 80
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u4ECA\u306F\u30B9\u30AD\u30C3\u30D7\u3067\u304D\u307E\u305B\u3093"
+--- !u!222 &1284471626
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1284471623}
+--- !u!1 &1331004209
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 1305146049}
-  - component: {fileID: 1305146050}
+  - component: {fileID: 1331004211}
+  - component: {fileID: 1331004210}
   m_Layer: 0
-  m_Name: Cards
+  m_Name: Main
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1305146049
+--- !u!114 &1331004210
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1331004209}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09b8e6b7a28ac5340ba8353cbfbb525b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1331004211
 Transform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1305146048}
+  m_GameObject: {fileID: 1331004209}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 1529483130}
-  - {fileID: 1285452356}
-  - {fileID: 1928212339}
-  - {fileID: 300998877}
-  m_Father: {fileID: 1314705845}
-  m_RootOrder: 0
+  - {fileID: 1782329958}
+  - {fileID: 1381140642}
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1305146050
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1305146048}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b8a943fad84b3eb4c8c757591f726a44, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  baseObject: {fileID: 1403885036071880, guid: 167ada71d1620b848aca9513b77fbbc8, type: 2}
-  autoGenerate: 1
-  cards: []
---- !u!1 &1314705844
+--- !u!1 &1365377807
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 1314705845}
+  - component: {fileID: 1365377808}
+  - component: {fileID: 1365377810}
+  - component: {fileID: 1365377809}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1365377808
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1365377807}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 538741713}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1365377809
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1365377807}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 6b40e3a31d4bf1c4dac4997225fa5e48, type: 3}
+    m_FontSize: 80
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 8
+    m_MaxSize: 80
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Yes
+--- !u!222 &1365377810
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1365377807}
+--- !u!1 &1381140641
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1381140642}
   m_Layer: 0
   m_Name: Enemy
   m_TagString: Untagged
@@ -1190,63 +1891,123 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1314705845
+--- !u!4 &1381140642
 Transform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1314705844}
+  m_GameObject: {fileID: 1381140641}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -2.067591, y: 4.518759, z: 0.4381711}
+  m_LocalPosition: {x: 0.08511131, y: 0.090188175, z: 0.41863984}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 1305146049}
-  - {fileID: 1452812159}
-  m_Father: {fileID: 1881867479}
+  - {fileID: 1782534839}
+  - {fileID: 1514091944}
+  m_Father: {fileID: 1331004211}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1452812158
+--- !u!1 &1466671210
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 1452812159}
-  - component: {fileID: 1452812160}
+  - component: {fileID: 1466671211}
   m_Layer: 0
-  m_Name: Shields
+  m_Name: Tomb
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1452812159
+--- !u!4 &1466671211
 Transform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1452812158}
+  m_GameObject: {fileID: 1466671210}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 1314705845}
-  m_RootOrder: 1
+  m_Father: {fileID: 1782534839}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1452812160
+--- !u!1 &1490103817
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1490103818}
+  - component: {fileID: 1490103820}
+  - component: {fileID: 1490103819}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1490103818
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1490103817}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 72119793}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1490103819
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1452812158}
+  m_GameObject: {fileID: 1490103817}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e30a481df283e044cb8e56f826894f58, type: 3}
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  baseObject: {fileID: 1404043438717670, guid: 31360c49a7d3ec74fa2369827259dadd, type: 2}
-  shields: []
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 6b40e3a31d4bf1c4dac4997225fa5e48, type: 3}
+    m_FontSize: 80
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 8
+    m_MaxSize: 80
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: OK
+--- !u!222 &1490103820
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1490103817}
 --- !u!1 &1493008206
 GameObject:
   m_ObjectHideFlags: 0
@@ -1315,46 +2076,48 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1493008206}
---- !u!1 &1529483129
+--- !u!1 &1514091943
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 1529483130}
-  - component: {fileID: 1529483131}
+  - component: {fileID: 1514091944}
+  - component: {fileID: 1514091945}
   m_Layer: 0
-  m_Name: Deck
+  m_Name: Shields
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1529483130
+--- !u!4 &1514091944
 Transform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1529483129}
+  m_GameObject: {fileID: 1514091943}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 1305146049}
-  m_RootOrder: 0
+  m_Father: {fileID: 1381140642}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1529483131
+--- !u!114 &1514091945
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1529483129}
+  m_GameObject: {fileID: 1514091943}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2fe499a46950d2143a29644e0688e6ff, type: 3}
+  m_Script: {fileID: 11500000, guid: e30a481df283e044cb8e56f826894f58, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  baseObject: {fileID: 1404043438717670, guid: 31360c49a7d3ec74fa2369827259dadd, type: 2}
+  shields: []
 --- !u!1 &1531428664
 GameObject:
   m_ObjectHideFlags: 0
@@ -1425,6 +2188,182 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1616758311
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1616758312}
+  - component: {fileID: 1616758313}
+  m_Layer: 0
+  m_Name: Deck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1616758312
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1616758311}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1782534839}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1616758313
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1616758311}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2fe499a46950d2143a29644e0688e6ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1617951924
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1617951925}
+  - component: {fileID: 1617951928}
+  - component: {fileID: 1617951927}
+  - component: {fileID: 1617951926}
+  - component: {fileID: 1617951929}
+  m_Layer: 5
+  m_Name: NoButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1617951925
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1617951924}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 153, y: -8.299999, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_Children:
+  - {fileID: 102522377}
+  m_Father: {fileID: 2129794890}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 153, y: -8.3}
+  m_SizeDelta: {x: 320, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1617951926
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1617951924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1617951927}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1617951929}
+        m_MethodName: WithdrawSkip
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &1617951927
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1617951924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1617951928
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1617951924}
+--- !u!114 &1617951929
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1617951924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 359c7bbb3603ab243a9af0a113e94687, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  targetCanvas: {fileID: 2129794889}
+  CannotCanvas: {fileID: 0}
 --- !u!1 &1680196725
 GameObject:
   m_ObjectHideFlags: 0
@@ -1616,6 +2555,103 @@ MonoBehaviour:
   baseObject: {fileID: 1403885036071880, guid: 167ada71d1620b848aca9513b77fbbc8, type: 2}
   autoGenerate: 1
   cards: []
+--- !u!1 &1752934213
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1752934217}
+  - component: {fileID: 1752934216}
+  - component: {fileID: 1752934215}
+  - component: {fileID: 1752934214}
+  m_Layer: 5
+  m_Name: CanvasForCannotSkipDialog
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1752934214
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1752934213}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1752934215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1752934213}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 1280}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &1752934216
+Canvas:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1752934213}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1752934217
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1752934213}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 197.5, y: 316, z: 0}
+  m_LocalScale: {x: 0.49375, y: 0.49375, z: 0.49375}
+  m_Children:
+  - {fileID: 671839309}
+  - {fileID: 2046536733}
+  - {fileID: 1284471624}
+  - {fileID: 72119793}
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1782329957
 GameObject:
   m_ObjectHideFlags: 0
@@ -1638,56 +2674,61 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1782329957}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -2.067591, y: 4.518759, z: 0.4381711}
+  m_LocalPosition: {x: 0.08511131, y: 0.090188175, z: 0.41863984}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1752830537}
   - {fileID: 1723556582}
-  m_Father: {fileID: 1881867479}
+  m_Father: {fileID: 1331004211}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1881867478
+--- !u!1 &1782534838
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 1881867479}
-  - component: {fileID: 1881867480}
+  - component: {fileID: 1782534839}
+  - component: {fileID: 1782534840}
   m_Layer: 0
-  m_Name: Main
+  m_Name: Cards
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1881867479
+--- !u!4 &1782534839
 Transform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1881867478}
+  m_GameObject: {fileID: 1782534838}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 2.1527023, y: -4.4285707, z: -0.01953125}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 1782329958}
-  - {fileID: 1314705845}
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
+  - {fileID: 1616758312}
+  - {fileID: 1139560945}
+  - {fileID: 549655251}
+  - {fileID: 1466671211}
+  m_Father: {fileID: 1381140642}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1881867480
+--- !u!114 &1782534840
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1881867478}
+  m_GameObject: {fileID: 1782534838}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 09b8e6b7a28ac5340ba8353cbfbb525b, type: 3}
+  m_Script: {fileID: 11500000, guid: b8a943fad84b3eb4c8c757591f726a44, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  baseObject: {fileID: 1403885036071880, guid: 167ada71d1620b848aca9513b77fbbc8, type: 2}
+  autoGenerate: 1
+  cards: []
 --- !u!1 &1890587234
 GameObject:
   m_ObjectHideFlags: 0
@@ -1773,34 +2814,142 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.Slider+SliderEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
---- !u!1 &1928212338
+--- !u!1 &1930088730
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 1928212339}
-  m_Layer: 0
-  m_Name: Field
+  - component: {fileID: 1930088731}
+  - component: {fileID: 1930088733}
+  - component: {fileID: 1930088732}
+  m_Layer: 5
+  m_Name: BackImage
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1928212339
-Transform:
+--- !u!224 &1930088731
+RectTransform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1928212338}
+  m_GameObject: {fileID: 1930088730}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 100, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 1305146049}
-  m_RootOrder: 2
+  m_Father: {fileID: 2129794890}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 100}
+  m_SizeDelta: {x: 600, y: 300}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1930088732
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1930088730}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.97794116, g: 0.9244817, b: 0.62559474, a: 0.803}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1930088733
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1930088730}
+--- !u!1 &2046536732
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2046536733}
+  - component: {fileID: 2046536735}
+  - component: {fileID: 2046536734}
+  m_Layer: 5
+  m_Name: BackImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2046536733
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2046536732}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 100, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1752934217}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 100}
+  m_SizeDelta: {x: 600, y: 300}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2046536734
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2046536732}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.97794116, g: 0.9244817, b: 0.62559474, a: 0.803}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &2046536735
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2046536732}
 --- !u!1 &2059113643
 GameObject:
   m_ObjectHideFlags: 0
@@ -1881,3 +3030,101 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2129794886
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2129794890}
+  - component: {fileID: 2129794889}
+  - component: {fileID: 2129794888}
+  - component: {fileID: 2129794887}
+  m_Layer: 5
+  m_Name: CanvasForModalDialog
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2129794887
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2129794886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &2129794888
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2129794886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 1280}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &2129794889
+Canvas:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2129794886}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &2129794890
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2129794886}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 197.5, y: 316, z: 0}
+  m_LocalScale: {x: 0.49375, y: 0.49375, z: 0.49375}
+  m_Children:
+  - {fileID: 164596187}
+  - {fileID: 1930088731}
+  - {fileID: 1142189510}
+  - {fileID: 538741713}
+  - {fileID: 1617951925}
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}

--- a/CardGame/Assets/Scripts/Scene/Main/GameManager.cs
+++ b/CardGame/Assets/Scripts/Scene/Main/GameManager.cs
@@ -8,11 +8,11 @@ public static class Variables { // 外部変数(Tap.csで検知されたオブ�
     public static GameObject player_tapped_obj = null; // プレイヤーがタップしたカードを保存する
     public static GameObject player_longtapped_obj = null; // プレイヤーが長押ししたカードを保存する(敵がフィールドに出したカードも含まれる)
     public static GameObject enemy_selected_obj = null; // 敵が選んだカードを保存する
-    public static bool player_canSummon = false; // プレイヤーが手札からフィールドにカードを出せるかどうか
-    public static bool enemy_canSummon = false; // 敵が手札からフィールドにカードを出せるかどうか
-    public static bool player_isSkippable = false; // プレイヤーがスキップできる状態かどうか
-    public static bool player_hasSkipped = false; // プレイヤーがスキップボタンが押されたかどうか
-    public static bool enemy_hasSkipped = false; // CPUがスキップボタンが押されたかどうか
+    public static bool attacker_canSummon = false; // 攻撃側が手札からフィールドにカードを出せるかどうか
+    public static bool defender_canSummon = false; // 防御側が手札からフィールドにカードを出せるかどうか
+    public static bool attacker_hasSkipped = false; // 攻撃側がスキップをしたかどうか
+    public static bool defender_hasSkipped = false; // 防御側がスキップをしたかどうか
+    public static bool player_isSkippable = false; // プレイヤーがスキップできる状態かどうか(使わないかも)
     public static float def_critical = 1.2f; // クリティカル防御率(防御ダウン率は各カード保有させる？)
     public static int damage = 0; // ダメージ
 }
@@ -47,35 +47,35 @@ public class TurnManager {
 }
 
 public class GameManager : MonoBehaviour {
-    GameObject[] players;
-    GameObject player_deck;
-    GameObject player_hand;
-    GameObject player_field;
-    GameObject player_tomb;
-    GameObject enemy_deck;
-    GameObject enemy_hand;
-    GameObject enemy_field;
-    GameObject enemy_tomb;
     TurnManager tm;
     int turn_total;
-    string attacker_name;
+    GameObject[] players;
+    GameObject attacker_deck;
+    GameObject attacker_hand;
+    GameObject attacker_field;
+    GameObject attacker_tomb;
+    GameObject defender_deck;
+    GameObject defender_hand;
+    GameObject defender_field;
+    GameObject defender_tomb;
+    string tmp_attacker_name;
 
     // Use this for initialization
     void Start() {
+        tm = new TurnManager(0);
+        turn_total = 1;
         players = new GameObject[2];
         players[0] = transform.Find("Player").gameObject;
         players[1] = transform.Find("Enemy").gameObject;
-        player_deck = players[0].transform.Find("Cards/Deck").gameObject;
-        player_hand = players[0].transform.Find("Cards/Hand").gameObject;
-        player_field = players[0].transform.Find("Cards/Field").gameObject;
-        player_tomb = players[0].transform.Find("Cards/Tomb").gameObject;
-        enemy_deck = players[1].transform.Find("Cards/Deck").gameObject;
-        enemy_hand = players[1].transform.Find("Cards/Hand").gameObject;
-        enemy_field = players[1].transform.Find("Cards/Field").gameObject;
-        enemy_tomb = players[1].transform.Find("Cards/Tomb").gameObject;
-        tm = new TurnManager(0);
-        turn_total = 1;
-        attacker_name = players[tm.Turn].name; // "Player"か"Enemy"が入る
+        attacker_deck = players[tm.Turn].transform.Find("Cards/Deck").gameObject;
+        attacker_hand = players[tm.Turn].transform.Find("Cards/Hand").gameObject;
+        attacker_field = players[tm.Turn].transform.Find("Cards/Field").gameObject;
+        attacker_tomb = players[tm.Turn].transform.Find("Cards/Tomb").gameObject;
+        defender_deck = players[tm.getNextTurn()].transform.Find("Cards/Deck").gameObject;
+        defender_hand = players[tm.getNextTurn()].transform.Find("Cards/Hand").gameObject;
+        defender_field = players[tm.getNextTurn()].transform.Find("Cards/Field").gameObject;
+        defender_tomb = players[tm.getNextTurn()].transform.Find("Cards/Tomb").gameObject;
+        tmp_attacker_name = players[tm.Turn].name; // "Player"か"Enemy"が入る
         StartCoroutine(GameLoop());
     }
 
@@ -83,17 +83,19 @@ public class GameManager : MonoBehaviour {
     private IEnumerator GameLoop() {
         Debug.Log("今のターンは、" + tm.Turn);
 
-        // ドロー
+        // 攻撃側と防御側双方がドローする
         yield return StartCoroutine(RoundDraw());
-        // 特殊カードorイベントカードを出す
+        // 攻撃側が特殊カードorイベントカードを出す
         yield return StartCoroutine(RoundSpEvent());
-        // 攻撃側の操作
+        // 攻撃側が攻撃カードをフィールドに出す
         yield return StartCoroutine(RoundAttack());
-        // 防御側の操作
+        // 防御側が防御カードをフィールドに出す
         yield return StartCoroutine(RoundDefense());
-        // ダメージ計算
-        yield return StartCoroutine(RoundCalcDamage());
-        // 墓地行き判定
+        // ダメージを計算・反映させる
+        if (!Variables.attacker_hasSkipped) {
+            yield return StartCoroutine(RoundCalcDamage());
+        }
+        // そのターンにフィールドに出たカードを墓地に送る
         yield return StartCoroutine(RoundTomb());
 
         if (isFinished()) {
@@ -112,157 +114,98 @@ public class GameManager : MonoBehaviour {
     private IEnumerator RoundDraw() {
         if (turn_total == 1) {
             // 最初のターンなら、双方とも自分のデッキ(山札)から5枚カードを引いて手札に加える
-            Utility.GetSafeComponent<DeckSet>(player_deck).draw5();
-            Utility.GetSafeComponent<DeckSet>(enemy_deck).draw5();
+            Utility.GetSafeComponent<DeckSet>(attacker_deck).draw5();
+            Utility.GetSafeComponent<DeckSet>(defender_deck).draw5();
         } else {
-            // 最初のターンでなければ、双方とも自分のデッキから1枚カードを引く手札に加える
-            Utility.GetSafeComponent<DeckSet>(player_deck).draw();
-            Utility.GetSafeComponent<DeckSet>(enemy_deck).draw();
+            // 最初のターンでなければ、双方とも自分のデッキから1枚カードを引いて手札に加える
+            Utility.GetSafeComponent<DeckSet>(attacker_deck).draw();
+            Utility.GetSafeComponent<DeckSet>(defender_deck).draw();
         }
-
-        // プレイヤーがカードを出せるかどうかのチェック
-        foreach (Transform hand_child in player_hand.transform) {
-            Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
-            if (hand_child_card.TYPE.Equals("ATK") || hand_child_card.TYPE.Equals("DEF")) {
-                Variables.player_canSummon = true;
-            }
-        }
-        // 敵がカードを出せるかどうかのチェック
-        foreach (Transform hand_child in enemy_hand.transform) {
-            Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
-            if (hand_child_card.TYPE.Equals("ATK") || hand_child_card.TYPE.Equals("DEF")) {
-                Variables.enemy_canSummon = true;
-            }
-        }
-
-        if (!Variables.player_canSummon) { // 手札からフィールドに出せるカードが1枚も無い場合、スキップ
-            // プレイヤー側のスキップ処理をする
-        }
-        if (!Variables.enemy_canSummon) {
-            // 敵側のスキップ処理をする
-        }
-
-        // カードをフィールドに出す処理(summonの引数にタップしたカードを指定する)
-        // ※プレイヤーがフィールドに出すカードを決めるまで待機する
-        // Utility.GetSafeComponent<HandSet>(player_hand).summon(Variables.player_tapped_obj);
-        yield return null;
+        yield return new WaitForSeconds(1.0f); // 1秒待つ
     }
 
     private IEnumerator RoundSpEvent() {
-        // 特殊カードorイベントカードを出す(イベントカードを使い終わったら、それを使った人の墓地に送らなければならない)
+        // 防御側のカード全てを選べないようにする
+        change_isSelectable(defender_hand, 0);
 
-        /*
+        // 攻撃側の手札で、特殊カードとイベントカード以外のカードを選べなくする
+        change_isSelectable(attacker_hand, 1);
+
+        // 攻撃側が特殊カードorイベントカードを出せるかどうかのチェック
+        check_canSummon(attacker_hand, 1);
+
+        // 攻撃側がここでスキップしたらこのコルーチンを停止する
+        if (Variables.attacker_hasSkipped) {
+            yield break;
+        }
+
+        // 手札からタップしたカードをフィールドに出す
+        // yield return new WaitUntil(): ()内の再開条件で指定した関数がtrueを返すまで処理を中断する(() => ...は、引数無しのラムダ式)
+        if (tmp_attacker_name.Equals("Player")) {
+            yield return new WaitUntil(() => Variables.player_tapped_obj != null);
+        } else if (tmp_attacker_name.Equals("Enemy")) {
+            yield return new WaitUntil(() => Variables.enemy_selected_obj != null);
+        }
+        summon_to_field(attacker_hand, 1);
         
-        // 特殊カード、イベントカード以外の手札を選べなくする
-        foreach (Transform hand_child in player_hand.transform) {
-            Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
-            if (!hand_child_card.TYPE.Equals("EV") && !hand_child_card.TYPE.Equals("SP")) {
-                hand_child_card.ISSELECTABLE = false;
-            }
-        }
-
-        // 手札から選んだ(タップした)カードをフィールドに出す
-        // プレイヤー側
-        string player_tapped_cardtype = Utility.GetSafeComponent<Card>(Variables.player_tapped_obj).TYPE;
-        if (player_tapped_cardtype.Equals("EV")) {
-            Utility.GetSafeComponent<HandSet>(player_hand).event_summon(Variables.player_tapped_obj);
-        } else if (player_tapped_cardtype.Equals("SP")) {
-            Utility.GetSafeComponent<HandSet>(player_hand).summon(Variables.player_tapped_obj);
-        } else if (Variables.player_hasSkipped) {
-            // スキップしたときはコルーチンを終了(この辺の実装は不完全)
-            yield break;
-        }
-
-        // 敵側
-        string enemy_tapped_cardtype = Utility.GetSafeComponent<Card>(Variables.enemy_selected_obj).TYPE;
-        if (enemy_tapped_cardtype.Equals("EV")) {
-            Utility.GetSafeComponent<HandSet>(enemy_hand).event_summon(Variables.enemy_selected_obj);
-        } else if (enemy_tapped_cardtype.Equals("SP")) {
-            Utility.GetSafeComponent<HandSet>(enemy_hand).summon(Variables.enemy_selected_obj);
-        } else if (Variables.enemy_hasSkipped) {
-            // スキップしたときはコルーチンを終了(この辺の実装は不完全)
-            yield break;
-        }
-        // 特殊カードorイベントカードが発動し終わったら墓地へ移動する
-
-        */
-        yield return null;
+        yield return new WaitForSeconds(1.0f); // 1秒待つ
     }
 
     private IEnumerator RoundAttack() {
-        // 攻撃側が攻撃カードを選んでフィールドに出す
+        // 防御側のカード全てを選べないようにする
+        change_isSelectable(defender_hand, 0);
 
-        /*
+        // 攻撃側の攻撃カード以外を選べないようにする
+        change_isSelectable(attacker_hand, 2);
 
-        if (attacker_name.Equals("Player")) {
-            foreach (Transform hand_child in enemy_hand.transform) { // 防御側のカード全てを選べないようにする(turnが0ならplayers[1]のカード選択を制限する)
-                Utility.GetSafeComponent<Card>(hand_child.gameObject).ISSELECTABLE = false;
-            }
-            foreach (Transform hand_child in player_hand.transform) { // 攻撃側の攻撃カード以外を選べないようにする
-                if (!Utility.GetSafeComponent<Card>(hand_child.gameObject).TYPE.Equals("ATK")) {
-                    Utility.GetSafeComponent<Card>(hand_child.gameObject).ISSELECTABLE = false;
-                }
-            }
-            Utility.GetSafeComponent<HandSet>(player_hand).summon(Variables.player_tapped_obj);
-        } else if (attacker_name.Equals("Enemy")) {
-            foreach (Transform hand_child in player_hand.transform) { // 防御側のカード全てを選べないようにする(turnが0ならplayers[1]のカード選択を制限する)
-                Utility.GetSafeComponent<Card>(hand_child.gameObject).ISSELECTABLE = false;
-            }
-            foreach (Transform hand_child in enemy_hand.transform) { // 攻撃側の攻撃カード以外を選べないようにする
-                if (!Utility.GetSafeComponent<Card>(hand_child.gameObject).TYPE.Equals("ATK")) {
-                    Utility.GetSafeComponent<Card>(hand_child.gameObject).ISSELECTABLE = false;
-                }
-            }
-            Utility.GetSafeComponent<HandSet>(enemy_hand).summon(Variables.enemy_selected_obj);
-        }
+        // 攻撃側がカードを出せるかどうかのチェック
+        check_canSummon(attacker_hand, 2);
 
-        */
-
-        /* この処理はここで必要なのか・・・？
-        if (Variables.player_hasSkipped) {
-            // スキップしたときはコルーチンを終了(この辺の実装は不完全)
+        // 攻撃側がここでスキップしたらこのコルーチンを停止する
+        if (Variables.attacker_hasSkipped) {
             yield break;
         }
-        */
-        yield return null;
+
+        // 手札からタップしたカードをフィールドに出す
+        // yield return new WaitUntil(): ()内の再開条件で指定した関数がtrueを返すまで処理を中断する(() => ...は、引数無しのラムダ式)
+        if (tmp_attacker_name.Equals("Player")) {
+            yield return new WaitUntil(() => Variables.player_tapped_obj != null);
+        } else if (tmp_attacker_name.Equals("Enemy")) {
+            yield return new WaitUntil(() => Variables.enemy_selected_obj != null);
+        }
+        summon_to_field(attacker_hand, 2);
+
+        yield return new WaitForSeconds(1.0f); // 1秒待つ
     }
 
     private IEnumerator RoundDefense() {
-        // 守備側が防御カードを選ぶ
-
-        /*
-
-        if (attacker_name.Equals("Player")) {
-            foreach (Transform hand_child in player_hand.transform) { // 攻撃側のカード全てを選べないようにする
-                Utility.GetSafeComponent<Card>(hand_child.gameObject).ISSELECTABLE = false;
-            }
-            foreach (Transform hand_child in enemy_hand.transform) { // 防御側の防御カード以外を選べないようにする
-                if (!Utility.GetSafeComponent<Card>(hand_child.gameObject).TYPE.Equals("DEF")) {
-                    Utility.GetSafeComponent<Card>(hand_child.gameObject).ISSELECTABLE = false;
-                }
-            }
-            Utility.GetSafeComponent<HandSet>(enemy_hand).summon(Variables.enemy_selected_obj);
-        } else if (attacker_name.Equals("Enemy")) {
-            foreach (Transform hand_child in enemy_hand.transform) { // 攻撃側のカード全てを選べないようにする
-                Utility.GetSafeComponent<Card>(hand_child.gameObject).ISSELECTABLE = false;
-            }
-            foreach (Transform hand_child in player_hand.transform) { // 防御側の防御カード以外を選べないようにする
-                if (!Utility.GetSafeComponent<Card>(hand_child.gameObject).TYPE.Equals("DEF")) {
-                    Utility.GetSafeComponent<Card>(hand_child.gameObject).ISSELECTABLE = false;
-                }
-            }
-            Utility.GetSafeComponent<HandSet>(player_hand).summon(Variables.player_tapped_obj);
-        }
-
-        */
-        
-        /* この処理はここで必要なのか・・・？
-        if (Variables.player_hasSkipped) {
-            // スキップしたときはコルーチンを終了(この辺の実装は不完全)
+        // 攻撃側(Player or Enemy)がスキップしていたら、防御側が手札を出すフェーズをスキップさせる
+        if (Variables.attacker_hasSkipped) {
             yield break;
         }
-        */
-        yield return null;
+
+        ///*
+
+        // 攻撃側のカード全てを選べないようにする
+        change_isSelectable(attacker_hand, 0);
+
+        // 防御側の防御カード以外を選べないようにする
+        change_isSelectable(defender_hand, 3);
+
+        // 防御側がカードを出せるかどうかのチェック
+        check_canSummon(defender_hand, 3);
+
+        // 手札からタップしたカードをフィールドに出す
+        // yield return new WaitUntil(): ()内の再開条件で指定した関数がtrueを返すまで処理を中断する(() => ...は、引数無しのラムダ式)
+        if (tmp_attacker_name.Equals("Player")) {
+            yield return new WaitUntil(() => Variables.enemy_selected_obj != null);
+        } else if (tmp_attacker_name.Equals("Enemy")) {
+            yield return new WaitUntil(() => Variables.player_tapped_obj != null);
+        }
+        summon_to_field(defender_hand, 3);
+
+        //*/
+        yield return new WaitForSeconds(1.0f); // 1秒待つ
     }
 
     private IEnumerator RoundCalcDamage() {
@@ -274,56 +217,197 @@ public class GameManager : MonoBehaviour {
 
         int atk_power = 0, def_power = 0;
         string field_atk_attr = "", field_def_attr;
-        if (attacker_name.Equals("Player")) {
-            atk_power = Utility.GetSafeComponent<Card>(player_field.transform.GetChild(0).gameObject).POWER;
-            def_power = Utility.GetSafeComponent<Card>(enemy_field.transform.GetChild(0).gameObject).POWER;
-            field_atk_attr = Utility.GetSafeComponent<Card>(player_field.transform.GetChild(0).gameObject).ATTRIBUTE;
-            field_def_attr = Utility.GetSafeComponent<Card>(enemy_field.transform.GetChild(0).gameObject).ATTRIBUTE;
-            if (field_def_attr.Equals(field_atk_attr)) {
-                Variables.def_critical = 0.5f;
-            }
-        } else if (attacker_name.Equals("Enemy")) {
-            atk_power = Utility.GetSafeComponent<Card>(enemy_field.transform.GetChild(0).gameObject).POWER;
-            def_power = Utility.GetSafeComponent<Card>(player_field.transform.GetChild(0).gameObject).POWER;
-            field_atk_attr = Utility.GetSafeComponent<Card>(enemy_field.transform.GetChild(0).gameObject).ATTRIBUTE;
-            field_def_attr = Utility.GetSafeComponent<Card>(player_field.transform.GetChild(0).gameObject).ATTRIBUTE;
-            if (field_def_attr.Equals(field_atk_attr)) {
-                Variables.def_critical = 0.5f;
-            }
+        atk_power = Utility.GetSafeComponent<Card>(attacker_field.transform.GetChild(0).gameObject).POWER;
+        def_power = Utility.GetSafeComponent<Card>(defender_field.transform.GetChild(0).gameObject).POWER;
+        field_atk_attr = Utility.GetSafeComponent<Card>(attacker_field.transform.GetChild(0).gameObject).ATTRIBUTE;
+        field_def_attr = Utility.GetSafeComponent<Card>(defender_field.transform.GetChild(0).gameObject).ATTRIBUTE;
+        // 防御側のフィールドに出ているカードの属性=攻撃側のフィールドに出ているカードならば、防御クリティカル発生
+        if (field_def_attr.Equals(field_atk_attr)) {
+            Variables.def_critical = 0.5f;
         }
 
         */
-        
+
         // 実際のダメージ計算。プレイヤーと敵が持つ3属性の攻撃力・防御力はどこで保持する・・・？
         // Variables.damage = atk_power - (int)(def_power * Variables.def_down * Variables.def_critical);
-        yield return null;
+        yield return new WaitForSeconds(1.0f); // 1秒待つ
     }
 
     private IEnumerator RoundTomb() {
-        // HPが0になったカードを墓地に送る。フィールドにいるカード(攻撃、防御、イベント)が、墓地に行く可能性有
-        /* if (FieldのカードのHP == 0) {
-         *     field_defside.parent = tomb_defside;
-         * }
-         */
-        yield return null;
+        // 特殊・イベントカードを含めた、フィールドに出ているカードを、ターン交代直前に墓地に移動させる
+        // HPが0になったシールドは、そのまま残しておく
+
+        if (attacker_field.transform.childCount > 0) {
+            // 攻撃側と防御側のフィールド双方に
+            GameObject attacker_field_child = attacker_field.transform.GetChild(0).gameObject;
+            attacker_field_child.transform.parent = attacker_tomb.transform;
+        }
+        if (defender_field.transform.childCount > 0) {
+            GameObject defender_field_child = defender_field.transform.GetChild(0).gameObject;
+            defender_field_child.transform.parent = defender_tomb.transform;
+        }
+        // イベントエリア内のカード移動は、HandSet.csのメソッドevent_summonの実装ができてから。
+
+        yield return new WaitForSeconds(1.0f); // 1秒待つ
     }
 
     private IEnumerator RoundTurnChange() {
         tm.changeTurn();
         turn_total++;
-        attacker_name = players[tm.Turn].name; // 攻守交代
-        Debug.Log(attacker_name);
-        yield return null;
+        tmp_attacker_name = players[tm.Turn].name;
+        // 攻守交代のため、攻撃側と防御側のGameObjectをそれぞれ更新
+        attacker_deck = players[tm.Turn].transform.Find("Cards/Deck").gameObject;
+        attacker_hand = players[tm.Turn].transform.Find("Cards/Hand").gameObject;
+        attacker_field = players[tm.Turn].transform.Find("Cards/Field").gameObject;
+        attacker_tomb = players[tm.Turn].transform.Find("Cards/Tomb").gameObject;
+        defender_deck = players[tm.getNextTurn()].transform.Find("Cards/Deck").gameObject;
+        defender_hand = players[tm.getNextTurn()].transform.Find("Cards/Hand").gameObject;
+        defender_field = players[tm.getNextTurn()].transform.Find("Cards/Field").gameObject;
+        defender_tomb = players[tm.getNextTurn()].transform.Find("Cards/Tomb").gameObject;
+        Debug.Log(tmp_attacker_name);
+        yield return new WaitForSeconds(1.0f); // 1秒待つ
     }
 
-    private IEnumerator RoundSkip() {
-        // ゲーム画面でスキップボタンが押されたらここを実行
-        yield return null;
+    // モードごとに、攻撃側or防御側のカードを選べないようにする
+    void change_isSelectable(GameObject hand, int mode) {
+        switch (mode) {
+            case 0: // 全てfalse
+                foreach (Transform hand_child in hand.transform) {
+                    Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
+                    hand_child_card.ISSELECTABLE = false;
+                }
+                break;
+            case 1: // 特殊カードとイベントカード以外をfalse
+                foreach (Transform hand_child in hand.transform) {
+                    Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
+                    if (!hand_child_card.TYPE.Equals("EV") && !hand_child_card.TYPE.Equals("SP")) {
+                        hand_child_card.ISSELECTABLE = false;
+                    }
+                }
+                break;
+            case 2: // 攻撃カード以外をfalse
+                foreach (Transform hand_child in hand.transform) {
+                    Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
+                    if (!hand_child_card.TYPE.Equals("ATK")) {
+                        hand_child_card.ISSELECTABLE = false;
+                    }
+                }
+                break;
+            case 3: // 防御カード以外をfalse
+                foreach (Transform hand_child in hand.transform) {
+                    Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
+                    if (!hand_child_card.TYPE.Equals("DEF")) {
+                        hand_child_card.ISSELECTABLE = false;
+                    }
+                }
+                break;
+            default: // モードが範囲外なら何もしない
+                break;
+        }
+    }
+
+    // 各フェーズで、攻撃側or防御側がカードを出せるかどうかチェックしてcanSummonを更新する
+    void check_canSummon(GameObject hand, int phase) {
+        switch (phase) {
+            case 1: // 特殊カード・イベントカードを出すフェーズで攻撃側がカードを出せるかどうか
+                foreach (Transform hand_child in hand.transform) {
+                    Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
+                    if (hand_child_card.TYPE.Equals("EV") || hand_child_card.TYPE.Equals("SP")) {
+                        Variables.attacker_canSummon = true;
+                    }
+                }
+                break;
+            case 2: // 攻撃フェーズで攻撃側がカードを出せるかどうか
+                foreach (Transform hand_child in hand.transform) {
+                    Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
+                    if (!hand_child_card.TYPE.Equals("ATK")) {
+                        Variables.attacker_canSummon = true;
+                    }
+                }
+                break;
+            case 3: // 防御フェーズで防御側がカードを出せるかどうか
+                foreach (Transform hand_child in hand.transform) {
+                    Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
+                    if (!hand_child_card.TYPE.Equals("DEF")) {
+                        Variables.defender_canSummon = true;
+                    }
+                }
+                break;
+            default: // モードが範囲外なら何もしない
+                break;
+        }
+    }
+
+    // 各フェーズで、攻撃側or防御側がカードを手札からフィールドに出す
+    void summon_to_field(GameObject hand, int phase) {
+        switch (phase) {
+            case 1: // RoundSpEventのフェーズで、攻撃側がカードを出す
+                if (tmp_attacker_name.Equals("Player")) {
+                    string player_tapped_cardtype = Utility.GetSafeComponent<Card>(Variables.player_tapped_obj).TYPE;
+                    if (player_tapped_cardtype.Equals("EV")) {
+                        Utility.GetSafeComponent<HandSet>(attacker_hand).event_summon(Variables.player_tapped_obj);
+                    } else if (player_tapped_cardtype.Equals("SP")) {
+                        Utility.GetSafeComponent<HandSet>(attacker_hand).summon(Variables.player_tapped_obj);
+                    }
+                    // 操作系の変数の中身をリセット
+                    Variables.player_tapped_obj = null;
+                    Variables.player_isSkippable = false;
+                } else if (tmp_attacker_name.Equals("Enemy")) {
+                    string enemy_selected_cardtype = Utility.GetSafeComponent<Card>(Variables.enemy_selected_obj).TYPE;
+                    if (enemy_selected_cardtype.Equals("EV")) {
+                        Utility.GetSafeComponent<HandSet>(attacker_hand).event_summon(Variables.enemy_selected_obj);
+                    } else if (enemy_selected_cardtype.Equals("SP")) {
+                        Utility.GetSafeComponent<HandSet>(attacker_hand).summon(Variables.enemy_selected_obj);
+                    }
+                    // 操作系の変数の中身をリセット
+                    Variables.enemy_selected_obj = null;
+                }
+                Variables.attacker_canSummon = false;
+                break;
+            case 2: // RoundAttackのフェーズで、攻撃側がカードを出す
+                if (tmp_attacker_name.Equals("Player")) {
+                    string player_tapped_cardtype = Utility.GetSafeComponent<Card>(Variables.player_tapped_obj).TYPE;
+                    if (player_tapped_cardtype.Equals("ATK")) {
+                        Utility.GetSafeComponent<HandSet>(attacker_hand).summon(Variables.player_tapped_obj);
+                    }
+                    // 操作系の変数の中身をリセット
+                    Variables.player_tapped_obj = null;
+                    Variables.player_isSkippable = false;
+                } else if (tmp_attacker_name.Equals("Enemy")) {
+                    string enemy_selected_cardtype = Utility.GetSafeComponent<Card>(Variables.enemy_selected_obj).TYPE;
+                    if (enemy_selected_cardtype.Equals("ATK")) {
+                        Utility.GetSafeComponent<HandSet>(attacker_hand).summon(Variables.enemy_selected_obj);
+                    }
+                    // 操作系の変数の中身をリセット
+                    Variables.enemy_selected_obj = null;
+                }
+                Variables.attacker_canSummon = false;
+                break;
+            case 3: // RoundDefenseのフェーズで、防御側がカードを出す
+                if (tmp_attacker_name.Equals("Player")) {
+                    string enemy_selected_cardtype = Utility.GetSafeComponent<Card>(Variables.enemy_selected_obj).TYPE;
+                    if (enemy_selected_cardtype.Equals("DEF")) {
+                        Utility.GetSafeComponent<HandSet>(defender_hand).summon(Variables.enemy_selected_obj);
+                    }
+                    // 操作系の変数の中身をリセット
+                    Variables.enemy_selected_obj = null;
+                } else if (tmp_attacker_name.Equals("Enemy")) {
+                    string player_tapped_cardtype = Utility.GetSafeComponent<Card>(Variables.player_tapped_obj).TYPE;
+                    if (player_tapped_cardtype.Equals("DEF")) {
+                        Utility.GetSafeComponent<HandSet>(defender_hand).summon(Variables.player_tapped_obj);
+                    }
+                    // 操作系の変数の中身をリセット
+                    Variables.player_tapped_obj = null;
+                    Variables.player_isSkippable = false;
+                }
+                Variables.defender_canSummon = false;
+                break;
+        }
     }
 
     // 1試合が終わったかどうかを判定する
     bool isFinished() {
-        /* if (3枚のシールドのどこかから情報を抜き取られたら) {
+        /* if (3枚のシールドの総HPが0になったら || 攻撃側と防御側の双方に、出せる攻撃カードが無くなったら？) {
          *     return true;
          * }
          */


### PR DESCRIPTION
・各フェーズで行う動作に合わせて、GameManagerクラスのメンバ変数の名前を変更した。
player_deck, player_hand, player_field, player_tomb, enemy_deck, enemy_hand, enemy_field, enemy_tomb
↓
attacker_deck, attacker_hand, attacker_field, attacker_tomb, defender_deck, defender_hand, defender_field, defender_tomb
それに伴い、ターン交代時に攻撃側と防御側のGameObjectの変数の中身を
更新するようにした。

・上記と同様に、Variablesクラスのstatic変数の名前も変更した。
player_canSummon, enemy_canSummon, player_hasSkipped, enemy_hasSkipped
↓
attacker_canSummon, defender_canSummon, attacker_hasSkipped, enemy_hasSkipped

・RoundDrawで、カードが出せるかどうかの処理を削除した。
山札からカードを引くだけなので不要。

・RoundSpEventを改善した。
特殊・イベントカードを出せるのは攻撃側だけで、防御側の処理は不要。
防御側の処理も書いていたため、削除した。
また、特殊orイベントカードの墓地への移動のタイミングを、RoundSpEventの最後からターン交代直前に変更した。
RoundTombにその処理を書いている。

・RoundAttackとRoundDefenseも改善した。
出せるカードが無い時に自動でスキップさせるのはNGなので、カードが選択されるまで待機するようにした。

・GameManager全体を通して
想定外の操作に対応するため、フェーズ間で持ち越したらマズい変数の情報のON/OFFの処理を追加した。
例えば、tapped_objとかみたいに、プレイヤー操作があるところのON/OFF。

・RoundTombを改善した。
HPが0になったカードを墓地に送ろうとしていたが、そのルールは無い。
1ターンが終わったら、場に出たカードを全て各プレイヤーの墓地に送るようにした。

・各フェーズで繰り返し行われる処理をメソッドにまとめた。
モードごとに、攻撃側or防御側のカードを選べないようにするメソッドchange_isSelectable、
各フェーズで、攻撃側or防御側がカードを出せるかどうかチェックしてcanSummonを更新するメソッドcheck_canSummon、
各フェーズで、攻撃側or防御側がカードを手札からフィールドに出すメソッドsummon_to_field。

--------------------------------------------------------------------------------
～実装上での疑問点～
・ダメージ計算で、防御ダウン率はどこから取得すればよい？
・HandSetのメソッドevent_summonは、イベントフィールドのUIができれば、あとは座標だけ考えるだけ？