### PR TITLE
敵の追加(主にカード,UI,動作)

### DIFF
--- a/CardGame/Assets/Resources/Prefabs/card.prefab
+++ b/CardGame/Assets/Resources/Prefabs/card.prefab
@@ -282,6 +282,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   card_id: 0
+  card_parent: 
 --- !u!114 &114222091522720070
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/CardGame/Assets/Scenes/Main.unity
+++ b/CardGame/Assets/Scenes/Main.unity
@@ -576,12 +576,12 @@ SpriteRenderer:
   m_SortingLayerID: -609710883
   m_SortingLayer: 1
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 0a03aa2c53a0a5444b175da71856e0bd, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 064ca237495fd204da57b8247f01141a, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 12, y: 7.66}
+  m_Size: {x: 7.66, y: 12}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -625,7 +625,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 333579406}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 319.99997, y: -150, z: 0}
+  m_LocalPosition: {x: 320, y: -150, z: 0}
   m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_Children:
   - {fileID: 623981424}
@@ -735,6 +735,80 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   targetCanvas: {fileID: 2129794889}
   CannotCanvas: {fileID: 1752934216}
+--- !u!1 &393397434
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 393397435}
+  - component: {fileID: 393397437}
+  - component: {fileID: 393397436}
+  m_Layer: 5
+  m_Name: Enemy_shield_I
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &393397435
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 393397434}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.000030517578, y: 325, z: 0}
+  m_LocalScale: {x: 0.50000006, y: 0.50000006, z: 0.50000006}
+  m_Children: []
+  m_Father: {fileID: 1083166826}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 400.00003, y: 325}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &393397436
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 393397434}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 6b40e3a31d4bf1c4dac4997225fa5e48, type: 3}
+    m_FontSize: 80
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 80
+    m_Alignment: 1
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!222 &393397437
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 393397434}
 --- !u!1 &473651035
 GameObject:
   m_ObjectHideFlags: 0
@@ -759,7 +833,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 473651035}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -299.99997, y: -100, z: 0}
+  m_LocalPosition: {x: -300, y: -100, z: 0}
   m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_Children: []
   m_Father: {fileID: 1083166826}
@@ -833,7 +907,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 535391226}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 125.00003, y: -325, z: 0}
+  m_LocalPosition: {x: 125, y: -325, z: 0}
   m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_Children: []
   m_Father: {fileID: 1083166826}
@@ -1019,6 +1093,46 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   targetCanvas: {fileID: 2129794889}
   CannotCanvas: {fileID: 0}
+--- !u!1 &549655250
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 549655251}
+  - component: {fileID: 549655252}
+  m_Layer: 0
+  m_Name: Field
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &549655251
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 549655250}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1782534839}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &549655252
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 549655250}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 37753bcad24be50459b5f499ffec9d1f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &565398957
 GameObject:
   m_ObjectHideFlags: 0
@@ -1187,7 +1301,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &671839308
 GameObject:
@@ -1257,6 +1371,80 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 671839308}
+--- !u!1 &952584621
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 952584622}
+  - component: {fileID: 952584624}
+  - component: {fileID: 952584623}
+  m_Layer: 5
+  m_Name: Enemy_shield_C
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &952584622
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 952584621}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -125, y: 325, z: 0}
+  m_LocalScale: {x: 0.50000006, y: 0.50000006, z: 0.50000006}
+  m_Children: []
+  m_Father: {fileID: 1083166826}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 275, y: 325}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &952584623
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 952584621}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 6b40e3a31d4bf1c4dac4997225fa5e48, type: 3}
+    m_FontSize: 80
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 80
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!222 &952584624
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 952584621}
 --- !u!1 &1064959131
 GameObject:
   m_ObjectHideFlags: 0
@@ -1373,8 +1561,8 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1083166822}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 89.5, y: 143.5, z: 0}
-  m_LocalScale: {x: 0.22375001, y: 0.22375001, z: 0.22375001}
+  m_LocalPosition: {x: 89, y: 142.5, z: 0}
+  m_LocalScale: {x: 0.2225, y: 0.2225, z: 0.2225}
   m_Children:
   - {fileID: 1747322646}
   - {fileID: 1157436251}
@@ -1382,14 +1570,58 @@ RectTransform:
   - {fileID: 473651036}
   - {fileID: 1890587235}
   - {fileID: 333579407}
+  - {fileID: 952584622}
+  - {fileID: 393397435}
+  - {fileID: 1972789061}
+  - {fileID: 1206698723}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1139560944
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1139560945}
+  - component: {fileID: 1139560946}
+  m_Layer: 0
+  m_Name: Hand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1139560945
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1139560944}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1782534839}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1139560946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1139560944}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 650afc76ac6e0324992086b6617d53b6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1142189509
 GameObject:
   m_ObjectHideFlags: 0
@@ -1528,7 +1760,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1157436250}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.000030517578, y: -325, z: 0}
+  m_LocalPosition: {x: 0, y: -325, z: 0}
   m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_Children: []
   m_Father: {fileID: 1083166826}
@@ -1618,34 +1850,80 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2fe499a46950d2143a29644e0688e6ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &1219102768
+--- !u!1 &1206698722
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 1219102769}
-  m_Layer: 0
-  m_Name: Resources
+  - component: {fileID: 1206698723}
+  - component: {fileID: 1206698725}
+  - component: {fileID: 1206698724}
+  m_Layer: 5
+  m_Name: Enemy_hp
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1219102769
-Transform:
+--- !u!224 &1206698723
+RectTransform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1219102768}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.08511131, y: 0.090188175, z: 0.41863984}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_GameObject: {fileID: 1206698722}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -300, y: 100, z: 0}
+  m_LocalScale: {x: 0.50000006, y: 0.50000006, z: 0.50000006}
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_Father: {fileID: 1083166826}
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 100.000015, y: 100}
+  m_SizeDelta: {x: 300, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1206698724
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1206698722}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 6b40e3a31d4bf1c4dac4997225fa5e48, type: 3}
+    m_FontSize: 80
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 80
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!222 &1206698725
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1206698722}
 --- !u!1 &1284471623
 GameObject:
   m_ObjectHideFlags: 0
@@ -1720,6 +1998,48 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1284471623}
+--- !u!1 &1331004209
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1331004211}
+  - component: {fileID: 1331004210}
+  m_Layer: 0
+  m_Name: Main
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1331004210
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1331004209}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 09b8e6b7a28ac5340ba8353cbfbb525b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1331004211
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1331004209}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1782329958}
+  - {fileID: 1381140642}
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1365377807
 GameObject:
   m_ObjectHideFlags: 0
@@ -1794,6 +2114,76 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1365377807}
+--- !u!1 &1381140641
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1381140642}
+  m_Layer: 0
+  m_Name: Enemy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1381140642
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1381140641}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.08511131, y: 0.090188175, z: 0.41863984}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1782534839}
+  - {fileID: 1514091944}
+  m_Father: {fileID: 1331004211}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1466671210
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1466671211}
+  - component: {fileID: 1466671212}
+  m_Layer: 0
+  m_Name: Tomb
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1466671211
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1466671210}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1782534839}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1466671212
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1466671210}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2326edf22cda83b4ab46972a1fa55396, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1490103817
 GameObject:
   m_ObjectHideFlags: 0
@@ -1936,6 +2326,48 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1493008206}
+--- !u!1 &1514091943
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1514091944}
+  - component: {fileID: 1514091945}
+  m_Layer: 0
+  m_Name: Shields
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1514091944
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1514091943}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1381140642}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1514091945
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1514091943}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e30a481df283e044cb8e56f826894f58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  baseObject: {fileID: 1404043438717670, guid: 31360c49a7d3ec74fa2369827259dadd, type: 2}
+  shields: []
 --- !u!1 &1531428664
 GameObject:
   m_ObjectHideFlags: 0
@@ -1944,6 +2376,7 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 1531428665}
+  - component: {fileID: 1531428666}
   m_Layer: 0
   m_Name: Field
   m_TagString: Untagged
@@ -1964,6 +2397,17 @@ Transform:
   m_Father: {fileID: 1752830537}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1531428666
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1531428664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 37753bcad24be50459b5f499ffec9d1f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1585801662
 GameObject:
   m_ObjectHideFlags: 0
@@ -2006,6 +2450,46 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1616758311
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1616758312}
+  - component: {fileID: 1616758313}
+  m_Layer: 0
+  m_Name: Deck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1616758312
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1616758311}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1782534839}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1616758313
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1616758311}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2fe499a46950d2143a29644e0688e6ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1617951924
 GameObject:
   m_ObjectHideFlags: 0
@@ -2150,6 +2634,7 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 1680196726}
+  - component: {fileID: 1680196727}
   m_Layer: 0
   m_Name: Tomb
   m_TagString: Untagged
@@ -2170,6 +2655,17 @@ Transform:
   m_Father: {fileID: 1752830537}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1680196727
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1680196725}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2326edf22cda83b4ab46972a1fa55396, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1723556581
 GameObject:
   m_ObjectHideFlags: 0
@@ -2236,7 +2732,7 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1747322645}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -124.99997, y: -325, z: 0}
+  m_LocalPosition: {x: -125, y: -325, z: 0}
   m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_Children: []
   m_Father: {fileID: 1083166826}
@@ -2331,7 +2827,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   baseObject: {fileID: 1403885036071880, guid: 167ada71d1620b848aca9513b77fbbc8, type: 2}
-  autoGenerate: 0
+  autoGenerate: 1
   cards: []
 --- !u!1 &1752934213
 GameObject:
@@ -2415,15 +2911,15 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1752934213}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 89.5, y: 143.5, z: 0}
-  m_LocalScale: {x: 0.22375001, y: 0.22375001, z: 0.22375001}
+  m_LocalPosition: {x: 89, y: 142.5, z: 0}
+  m_LocalScale: {x: 0.2225, y: 0.2225, z: 0.2225}
   m_Children:
   - {fileID: 671839309}
   - {fileID: 2046536733}
   - {fileID: 1284471624}
   - {fileID: 72119793}
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2451,15 +2947,62 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1782329957}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.08511131, y: 0.090188175, z: 0.41863984}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1752830537}
   - {fileID: 1723556582}
-  m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_Father: {fileID: 1331004211}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1782534838
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1782534839}
+  - component: {fileID: 1782534840}
+  m_Layer: 0
+  m_Name: Cards
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1782534839
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1782534838}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1616758312}
+  - {fileID: 1139560945}
+  - {fileID: 549655251}
+  - {fileID: 1466671211}
+  m_Father: {fileID: 1381140642}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1782534840
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1782534838}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b8a943fad84b3eb4c8c757591f726a44, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  baseObject: {fileID: 1403885036071880, guid: 167ada71d1620b848aca9513b77fbbc8, type: 2}
+  autoGenerate: 1
+  cards: []
 --- !u!1 &1890587234
 GameObject:
   m_ObjectHideFlags: 0
@@ -2613,6 +3156,80 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1930088730}
+--- !u!1 &1972789060
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1972789061}
+  - component: {fileID: 1972789063}
+  - component: {fileID: 1972789062}
+  m_Layer: 5
+  m_Name: Enemy_shield_A
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1972789061
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1972789060}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 125, y: 325, z: 0}
+  m_LocalScale: {x: 0.50000006, y: 0.50000006, z: 0.50000006}
+  m_Children: []
+  m_Father: {fileID: 1083166826}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 525, y: 325}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1972789062
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1972789060}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 6b40e3a31d4bf1c4dac4997225fa5e48, type: 3}
+    m_FontSize: 80
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 4
+    m_MaxSize: 80
+    m_Alignment: 2
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!222 &1972789063
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1972789060}
 --- !u!1 &2046536732
 GameObject:
   m_ObjectHideFlags: 0
@@ -2859,8 +3476,8 @@ RectTransform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2129794886}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 89.5, y: 143.5, z: 0}
-  m_LocalScale: {x: 0.22375001, y: 0.22375001, z: 0.22375001}
+  m_LocalPosition: {x: 89, y: 142.5, z: 0}
+  m_LocalScale: {x: 0.2225, y: 0.2225, z: 0.2225}
   m_Children:
   - {fileID: 164596187}
   - {fileID: 1930088731}
@@ -2868,7 +3485,7 @@ RectTransform:
   - {fileID: 538741713}
   - {fileID: 1617951925}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}

--- a/CardGame/Assets/Scripts/Module/Tap.cs
+++ b/CardGame/Assets/Scripts/Module/Tap.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -56,10 +56,12 @@ public class Tap : MonoBehaviour, IPointerClickHandler , IPointerDownHandler , I
         }
     }
 
-    //ドラッグ・スワイプの関数(実機用にもう少し複雑にしてもよいかも)
+    //ドラッグ・スワイプの関数(実機用にもう少し複雑にしてもよいかも・プレイヤーのみ動作)
     public void OnDrag(PointerEventData eventData) {
-        //Debug.Log("ドラッグ中");
-        sld.value -= eventData.delta.x * 0.005f;
+        if (GetComponent<Card>().PARENT == "Player") {
+            //Debug.Log("ドラッグ中");
+            sld.value -= eventData.delta.x * 0.005f;
+        }
     }
 
     //タップ・長押し開始の関数

--- a/CardGame/Assets/Scripts/Scene/Main/Card.cs
+++ b/CardGame/Assets/Scripts/Scene/Main/Card.cs
@@ -13,6 +13,7 @@ public class Card : MonoBehaviour {
     private string card_describe;
     private int card_power;
     private string card_type;
+    private string card_parent;  //playerかenemy所属どちらか,CardManagerで値いれる
     private bool isBack;  //裏表(trueで裏)
     private bool isSelectable;  //その時選べるかどうか(ゲームから変更する？)
 
@@ -124,6 +125,11 @@ public class Card : MonoBehaviour {
         get { return card_type; }
     }
 
+    public string PARENT {
+        set { card_parent = value; }
+        get { return card_parent;  }
+    }
+
     public bool ISBACK {
         set { isBack = value; }
         get { return isBack; }
@@ -149,6 +155,21 @@ public class Card : MonoBehaviour {
         GameObject child = transform.Find("card_picture").gameObject;
         SpriteRenderer child_sr = child.GetComponent<SpriteRenderer>();
         child_sr.sprite = sp;
+    }
+
+    //追加部分(特殊カード)
+    public void specialCard(){
+        
+    }
+    //追加部分(イベントカード)
+    public void eventCard(){
+        if (card_id == 17){
+
+        }else if (card_id == 18){
+
+        }else if (card_id == 19){
+
+        }
     }
 
 }

--- a/CardGame/Assets/Scripts/Scene/Main/CardManager.cs
+++ b/CardGame/Assets/Scripts/Scene/Main/CardManager.cs
@@ -52,6 +52,7 @@ public class CardManager : MonoBehaviour {
                 card.DESCRIBE = data[3];
                 card.POWER = Convert.ToInt32(data[4]);
                 card.TYPE = data[5];
+                card.PARENT = transform.parent.name;
 
             }
 

--- a/CardGame/Assets/Scripts/Scene/Main/DeckSet.cs
+++ b/CardGame/Assets/Scripts/Scene/Main/DeckSet.cs
@@ -23,28 +23,31 @@ public class DeckSet : MonoBehaviour {
 	// Update is called once per frame
 	void Update () {
         setCards();
-
+        /*
         a++;
         if (a > 5 && b<20) {
             draw();
             a = 0;
             b++;
         }
+        */
 	}
 
     //デッキ内のカードを正しい位置に移動(以前とカード枚数が違ったら)
     public void setCards() {
-        int Childcount = transform.childCount;
-        if (count != Childcount) {
-            count = Childcount;
-            children = new GameObject[count];
-            for (int i = 0; count > i; i++) {
-                children[i] = transform.GetChild(i).gameObject;
+        count = transform.childCount;
+        children = new GameObject[count];
+        for (int i = 0; count > i; i++) {
+            children[i] = transform.GetChild(i).gameObject;
+            if (player_name == "Player") {
                 children[i].transform.localPosition = new Vector3(3, (float)-2.5, 0);
-                children[i].GetComponent<Card>().ISBACK = true;  //デッキ内では裏
-                children[i].GetComponent<Card>().ISSELECTABLE = false;  //デッキ内では詳細表示不可
+            } else {
+                children[i].transform.localPosition = new Vector3(-3, (float)2.5, 0);
             }
+            children[i].GetComponent<Card>().ISBACK = true;  //デッキ内では裏
+            children[i].GetComponent<Card>().ISSELECTABLE = false;  //デッキ内では詳細表示不可
         }
+
     }
 
     //手札を引く・カードを一枚手札に送る(山札にカードがなかったらスルー)

--- a/CardGame/Assets/Scripts/Scene/Main/FieldSet.cs
+++ b/CardGame/Assets/Scripts/Scene/Main/FieldSet.cs
@@ -5,12 +5,13 @@ using UnityEngine;
 public class FieldSet : MonoBehaviour {
 
     //メンバ変数
-    int a = 0;
+    string player_name;
     int count;
     GameObject[] children;  //本来フィールドにはカード一枚だけど一応
 
     // Use this for initialization
     void Start () {
+        player_name = transform.parent.parent.name;
         count = transform.childCount;
     }
 	
@@ -27,7 +28,11 @@ public class FieldSet : MonoBehaviour {
             children = new GameObject[count];
             for (int i = 0; count > i; i++) {
                 children[i] = transform.GetChild(i).gameObject;
-                children[i].transform.localPosition = new Vector3(0, (float)-1.15, 0);
+                if (player_name == "Player") {
+                    children[i].transform.localPosition = new Vector3(0, (float)-1.15, 0);
+                }else {
+                    children[i].transform.localPosition = new Vector3(0, (float)1.15, 0);
+                }
                 children[i].GetComponent<Card>().ISSELECTABLE = false;  //選択不可に
             }
         }

--- a/CardGame/Assets/Scripts/Scene/Main/GameManager.cs
+++ b/CardGame/Assets/Scripts/Scene/Main/GameManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -8,11 +8,11 @@ public static class Variables { // 外部変数(Tap.csで検知されたオブ�
     public static GameObject player_tapped_obj = null; // プレイヤーがタップしたカードを保存する
     public static GameObject player_longtapped_obj = null; // プレイヤーが長押ししたカードを保存する(敵がフィールドに出したカードも含まれる)
     public static GameObject enemy_selected_obj = null; // 敵が選んだカードを保存する
-    public static bool player_canSummon = false; // プレイヤーが手札からフィールドにカードを出せるかどうか
-    public static bool enemy_canSummon = false; // 敵が手札からフィールドにカードを出せるかどうか
-    public static bool player_isSkippable = false; // プレイヤーがスキップできる状態かどうか
-    public static bool player_hasSkipped = false; // プレイヤーがスキップボタンが押されたかどうか
-    public static bool enemy_hasSkipped = false; // CPUがスキップボタンが押されたかどうか
+    public static bool attacker_canSummon = false; // 攻撃側が手札からフィールドにカードを出せるかどうか
+    public static bool defender_canSummon = false; // 防御側が手札からフィールドにカードを出せるかどうか
+    public static bool attacker_hasSkipped = false; // 攻撃側がスキップをしたかどうか
+    public static bool defender_hasSkipped = false; // 防御側がスキップをしたかどうか
+    public static bool player_isSkippable = false; // プレイヤーがスキップできる状態かどうか(使わないかも)
     public static float def_critical = 1.2f; // クリティカル防御率(防御ダウン率は各カード保有させる？)
     public static int damage = 0; // ダメージ
 }
@@ -47,35 +47,35 @@ public class TurnManager {
 }
 
 public class GameManager : MonoBehaviour {
-    GameObject[] players;
-    GameObject player_deck;
-    GameObject player_hand;
-    GameObject player_field;
-    GameObject player_tomb;
-    GameObject enemy_deck;
-    GameObject enemy_hand;
-    GameObject enemy_field;
-    GameObject enemy_tomb;
     TurnManager tm;
     int turn_total;
-    string attacker_name;
+    GameObject[] players;
+    GameObject attacker_deck;
+    GameObject attacker_hand;
+    GameObject attacker_field;
+    GameObject attacker_tomb;
+    GameObject defender_deck;
+    GameObject defender_hand;
+    GameObject defender_field;
+    GameObject defender_tomb;
+    string tmp_attacker_name;
 
     // Use this for initialization
     void Start() {
+        tm = new TurnManager(0);
+        turn_total = 1;
         players = new GameObject[2];
         players[0] = transform.Find("Player").gameObject;
         players[1] = transform.Find("Enemy").gameObject;
-        player_deck = players[0].transform.Find("Cards/Deck").gameObject;
-        player_hand = players[0].transform.Find("Cards/Hand").gameObject;
-        player_field = players[0].transform.Find("Cards/Field").gameObject;
-        player_tomb = players[0].transform.Find("Cards/Tomb").gameObject;
-        enemy_deck = players[1].transform.Find("Cards/Deck").gameObject;
-        enemy_hand = players[1].transform.Find("Cards/Hand").gameObject;
-        enemy_field = players[1].transform.Find("Cards/Field").gameObject;
-        enemy_tomb = players[1].transform.Find("Cards/Tomb").gameObject;
-        tm = new TurnManager(0);
-        turn_total = 1;
-        attacker_name = players[tm.Turn].name; // "Player"か"Enemy"が入る
+        attacker_deck = players[tm.Turn].transform.Find("Cards/Deck").gameObject;
+        attacker_hand = players[tm.Turn].transform.Find("Cards/Hand").gameObject;
+        attacker_field = players[tm.Turn].transform.Find("Cards/Field").gameObject;
+        attacker_tomb = players[tm.Turn].transform.Find("Cards/Tomb").gameObject;
+        defender_deck = players[tm.getNextTurn()].transform.Find("Cards/Deck").gameObject;
+        defender_hand = players[tm.getNextTurn()].transform.Find("Cards/Hand").gameObject;
+        defender_field = players[tm.getNextTurn()].transform.Find("Cards/Field").gameObject;
+        defender_tomb = players[tm.getNextTurn()].transform.Find("Cards/Tomb").gameObject;
+        tmp_attacker_name = players[tm.Turn].name; // "Player"か"Enemy"が入る
         StartCoroutine(GameLoop());
     }
 
@@ -83,17 +83,19 @@ public class GameManager : MonoBehaviour {
     private IEnumerator GameLoop() {
         Debug.Log("今のターンは、" + tm.Turn);
 
-        // ドロー
+        // 攻撃側と防御側双方がドローする
         yield return StartCoroutine(RoundDraw());
-        // 特殊カードorイベントカードを出す
+        // 攻撃側が特殊カードorイベントカードを出す
         yield return StartCoroutine(RoundSpEvent());
-        // 攻撃側の操作
+        // 攻撃側が攻撃カードをフィールドに出す
         yield return StartCoroutine(RoundAttack());
-        // 防御側の操作
+        // 防御側が防御カードをフィールドに出す
         yield return StartCoroutine(RoundDefense());
-        // ダメージ計算
-        yield return StartCoroutine(RoundCalcDamage());
-        // 墓地行き判定
+        // ダメージを計算・反映させる
+        if (!Variables.attacker_hasSkipped) {
+            yield return StartCoroutine(RoundCalcDamage());
+        }
+        // そのターンにフィールドに出たカードを墓地に送る
         yield return StartCoroutine(RoundTomb());
 
         if (isFinished()) {
@@ -112,157 +114,98 @@ public class GameManager : MonoBehaviour {
     private IEnumerator RoundDraw() {
         if (turn_total == 1) {
             // 最初のターンなら、双方とも自分のデッキ(山札)から5枚カードを引いて手札に加える
-            Utility.GetSafeComponent<DeckSet>(player_deck).draw5();
-            Utility.GetSafeComponent<DeckSet>(enemy_deck).draw5();
+            Utility.GetSafeComponent<DeckSet>(attacker_deck).draw5();
+            Utility.GetSafeComponent<DeckSet>(defender_deck).draw5();
         } else {
-            // 最初のターンでなければ、双方とも自分のデッキから1枚カードを引く手札に加える
-            Utility.GetSafeComponent<DeckSet>(player_deck).draw();
-            Utility.GetSafeComponent<DeckSet>(enemy_deck).draw();
+            // 最初のターンでなければ、双方とも自分のデッキから1枚カードを引いて手札に加える
+            Utility.GetSafeComponent<DeckSet>(attacker_deck).draw();
+            Utility.GetSafeComponent<DeckSet>(defender_deck).draw();
         }
-
-        // プレイヤーがカードを出せるかどうかのチェック
-        foreach (Transform hand_child in player_hand.transform) {
-            Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
-            if (hand_child_card.TYPE.Equals("ATK") || hand_child_card.TYPE.Equals("DEF")) {
-                Variables.player_canSummon = true;
-            }
-        }
-        // 敵がカードを出せるかどうかのチェック
-        foreach (Transform hand_child in enemy_hand.transform) {
-            Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
-            if (hand_child_card.TYPE.Equals("ATK") || hand_child_card.TYPE.Equals("DEF")) {
-                Variables.enemy_canSummon = true;
-            }
-        }
-
-        if (!Variables.player_canSummon) { // 手札からフィールドに出せるカードが1枚も無い場合、スキップ
-            // プレイヤー側のスキップ処理をする
-        }
-        if (!Variables.enemy_canSummon) {
-            // 敵側のスキップ処理をする
-        }
-
-        // カードをフィールドに出す処理(summonの引数にタップしたカードを指定する)
-        // ※プレイヤーがフィールドに出すカードを決めるまで待機する
-        // Utility.GetSafeComponent<HandSet>(player_hand).summon(Variables.player_tapped_obj);
-        yield return null;
+        yield return new WaitForSeconds(1.0f); // 1秒待つ
     }
 
     private IEnumerator RoundSpEvent() {
-        // 特殊カードorイベントカードを出す(イベントカードを使い終わったら、それを使った人の墓地に送らなければならない)
+        // 防御側のカード全てを選べないようにする
+        change_isSelectable(defender_hand, 0);
 
-        /*
+        // 攻撃側の手札で、特殊カードとイベントカード以外のカードを選べなくする
+        change_isSelectable(attacker_hand, 1);
+
+        // 攻撃側が特殊カードorイベントカードを出せるかどうかのチェック
+        check_canSummon(attacker_hand, 1);
+
+        // 攻撃側がここでスキップしたらこのコルーチンを停止する
+        if (Variables.attacker_hasSkipped) {
+            yield break;
+        }
+
+        // 手札からタップしたカードをフィールドに出す
+        // yield return new WaitUntil(): ()内の再開条件で指定した関数がtrueを返すまで処理を中断する(() => ...は、引数無しのラムダ式)
+        if (tmp_attacker_name.Equals("Player")) {
+            yield return new WaitUntil(() => Variables.player_tapped_obj != null);
+        } else if (tmp_attacker_name.Equals("Enemy")) {
+            yield return new WaitUntil(() => Variables.enemy_selected_obj != null);
+        }
+        summon_to_field(attacker_hand, 1);
         
-        // 特殊カード、イベントカード以外の手札を選べなくする
-        foreach (Transform hand_child in player_hand.transform) {
-            Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
-            if (!hand_child_card.TYPE.Equals("EV") && !hand_child_card.TYPE.Equals("SP")) {
-                hand_child_card.ISSELECTABLE = false;
-            }
-        }
-
-        // 手札から選んだ(タップした)カードをフィールドに出す
-        // プレイヤー側
-        string player_tapped_cardtype = Utility.GetSafeComponent<Card>(Variables.player_tapped_obj).TYPE;
-        if (player_tapped_cardtype.Equals("EV")) {
-            Utility.GetSafeComponent<HandSet>(player_hand).event_summon(Variables.player_tapped_obj);
-        } else if (player_tapped_cardtype.Equals("SP")) {
-            Utility.GetSafeComponent<HandSet>(player_hand).summon(Variables.player_tapped_obj);
-        } else if (Variables.player_hasSkipped) {
-            // スキップしたときはコルーチンを終了(この辺の実装は不完全)
-            yield break;
-        }
-
-        // 敵側
-        string enemy_tapped_cardtype = Utility.GetSafeComponent<Card>(Variables.enemy_selected_obj).TYPE;
-        if (enemy_tapped_cardtype.Equals("EV")) {
-            Utility.GetSafeComponent<HandSet>(enemy_hand).event_summon(Variables.enemy_selected_obj);
-        } else if (enemy_tapped_cardtype.Equals("SP")) {
-            Utility.GetSafeComponent<HandSet>(enemy_hand).summon(Variables.enemy_selected_obj);
-        } else if (Variables.enemy_hasSkipped) {
-            // スキップしたときはコルーチンを終了(この辺の実装は不完全)
-            yield break;
-        }
-        // 特殊カードorイベントカードが発動し終わったら墓地へ移動する
-
-        */
-        yield return null;
+        yield return new WaitForSeconds(1.0f); // 1秒待つ
     }
 
     private IEnumerator RoundAttack() {
-        // 攻撃側が攻撃カードを選んでフィールドに出す
+        // 防御側のカード全てを選べないようにする
+        change_isSelectable(defender_hand, 0);
 
-        /*
+        // 攻撃側の攻撃カード以外を選べないようにする
+        change_isSelectable(attacker_hand, 2);
 
-        if (attacker_name.Equals("Player")) {
-            foreach (Transform hand_child in enemy_hand.transform) { // 防御側のカード全てを選べないようにする(turnが0ならplayers[1]のカード選択を制限する)
-                Utility.GetSafeComponent<Card>(hand_child.gameObject).ISSELECTABLE = false;
-            }
-            foreach (Transform hand_child in player_hand.transform) { // 攻撃側の攻撃カード以外を選べないようにする
-                if (!Utility.GetSafeComponent<Card>(hand_child.gameObject).TYPE.Equals("ATK")) {
-                    Utility.GetSafeComponent<Card>(hand_child.gameObject).ISSELECTABLE = false;
-                }
-            }
-            Utility.GetSafeComponent<HandSet>(player_hand).summon(Variables.player_tapped_obj);
-        } else if (attacker_name.Equals("Enemy")) {
-            foreach (Transform hand_child in player_hand.transform) { // 防御側のカード全てを選べないようにする(turnが0ならplayers[1]のカード選択を制限する)
-                Utility.GetSafeComponent<Card>(hand_child.gameObject).ISSELECTABLE = false;
-            }
-            foreach (Transform hand_child in enemy_hand.transform) { // 攻撃側の攻撃カード以外を選べないようにする
-                if (!Utility.GetSafeComponent<Card>(hand_child.gameObject).TYPE.Equals("ATK")) {
-                    Utility.GetSafeComponent<Card>(hand_child.gameObject).ISSELECTABLE = false;
-                }
-            }
-            Utility.GetSafeComponent<HandSet>(enemy_hand).summon(Variables.enemy_selected_obj);
-        }
+        // 攻撃側がカードを出せるかどうかのチェック
+        check_canSummon(attacker_hand, 2);
 
-        */
-
-        /* この処理はここで必要なのか・・・？
-        if (Variables.player_hasSkipped) {
-            // スキップしたときはコルーチンを終了(この辺の実装は不完全)
+        // 攻撃側がここでスキップしたらこのコルーチンを停止する
+        if (Variables.attacker_hasSkipped) {
             yield break;
         }
-        */
-        yield return null;
+
+        // 手札からタップしたカードをフィールドに出す
+        // yield return new WaitUntil(): ()内の再開条件で指定した関数がtrueを返すまで処理を中断する(() => ...は、引数無しのラムダ式)
+        if (tmp_attacker_name.Equals("Player")) {
+            yield return new WaitUntil(() => Variables.player_tapped_obj != null);
+        } else if (tmp_attacker_name.Equals("Enemy")) {
+            yield return new WaitUntil(() => Variables.enemy_selected_obj != null);
+        }
+        summon_to_field(attacker_hand, 2);
+
+        yield return new WaitForSeconds(1.0f); // 1秒待つ
     }
 
     private IEnumerator RoundDefense() {
-        // 守備側が防御カードを選ぶ
-
-        /*
-
-        if (attacker_name.Equals("Player")) {
-            foreach (Transform hand_child in player_hand.transform) { // 攻撃側のカード全てを選べないようにする
-                Utility.GetSafeComponent<Card>(hand_child.gameObject).ISSELECTABLE = false;
-            }
-            foreach (Transform hand_child in enemy_hand.transform) { // 防御側の防御カード以外を選べないようにする
-                if (!Utility.GetSafeComponent<Card>(hand_child.gameObject).TYPE.Equals("DEF")) {
-                    Utility.GetSafeComponent<Card>(hand_child.gameObject).ISSELECTABLE = false;
-                }
-            }
-            Utility.GetSafeComponent<HandSet>(enemy_hand).summon(Variables.enemy_selected_obj);
-        } else if (attacker_name.Equals("Enemy")) {
-            foreach (Transform hand_child in enemy_hand.transform) { // 攻撃側のカード全てを選べないようにする
-                Utility.GetSafeComponent<Card>(hand_child.gameObject).ISSELECTABLE = false;
-            }
-            foreach (Transform hand_child in player_hand.transform) { // 防御側の防御カード以外を選べないようにする
-                if (!Utility.GetSafeComponent<Card>(hand_child.gameObject).TYPE.Equals("DEF")) {
-                    Utility.GetSafeComponent<Card>(hand_child.gameObject).ISSELECTABLE = false;
-                }
-            }
-            Utility.GetSafeComponent<HandSet>(player_hand).summon(Variables.player_tapped_obj);
-        }
-
-        */
-        
-        /* この処理はここで必要なのか・・・？
-        if (Variables.player_hasSkipped) {
-            // スキップしたときはコルーチンを終了(この辺の実装は不完全)
+        // 攻撃側(Player or Enemy)がスキップしていたら、防御側が手札を出すフェーズをスキップさせる
+        if (Variables.attacker_hasSkipped) {
             yield break;
         }
-        */
-        yield return null;
+
+        ///*
+
+        // 攻撃側のカード全てを選べないようにする
+        change_isSelectable(attacker_hand, 0);
+
+        // 防御側の防御カード以外を選べないようにする
+        change_isSelectable(defender_hand, 3);
+
+        // 防御側がカードを出せるかどうかのチェック
+        check_canSummon(defender_hand, 3);
+
+        // 手札からタップしたカードをフィールドに出す
+        // yield return new WaitUntil(): ()内の再開条件で指定した関数がtrueを返すまで処理を中断する(() => ...は、引数無しのラムダ式)
+        if (tmp_attacker_name.Equals("Player")) {
+            yield return new WaitUntil(() => Variables.enemy_selected_obj != null);
+        } else if (tmp_attacker_name.Equals("Enemy")) {
+            yield return new WaitUntil(() => Variables.player_tapped_obj != null);
+        }
+        summon_to_field(defender_hand, 3);
+
+        //*/
+        yield return new WaitForSeconds(1.0f); // 1秒待つ
     }
 
     private IEnumerator RoundCalcDamage() {
@@ -274,56 +217,197 @@ public class GameManager : MonoBehaviour {
 
         int atk_power = 0, def_power = 0;
         string field_atk_attr = "", field_def_attr;
-        if (attacker_name.Equals("Player")) {
-            atk_power = Utility.GetSafeComponent<Card>(player_field.transform.GetChild(0).gameObject).POWER;
-            def_power = Utility.GetSafeComponent<Card>(enemy_field.transform.GetChild(0).gameObject).POWER;
-            field_atk_attr = Utility.GetSafeComponent<Card>(player_field.transform.GetChild(0).gameObject).ATTRIBUTE;
-            field_def_attr = Utility.GetSafeComponent<Card>(enemy_field.transform.GetChild(0).gameObject).ATTRIBUTE;
-            if (field_def_attr.Equals(field_atk_attr)) {
-                Variables.def_critical = 0.5f;
-            }
-        } else if (attacker_name.Equals("Enemy")) {
-            atk_power = Utility.GetSafeComponent<Card>(enemy_field.transform.GetChild(0).gameObject).POWER;
-            def_power = Utility.GetSafeComponent<Card>(player_field.transform.GetChild(0).gameObject).POWER;
-            field_atk_attr = Utility.GetSafeComponent<Card>(enemy_field.transform.GetChild(0).gameObject).ATTRIBUTE;
-            field_def_attr = Utility.GetSafeComponent<Card>(player_field.transform.GetChild(0).gameObject).ATTRIBUTE;
-            if (field_def_attr.Equals(field_atk_attr)) {
-                Variables.def_critical = 0.5f;
-            }
+        atk_power = Utility.GetSafeComponent<Card>(attacker_field.transform.GetChild(0).gameObject).POWER;
+        def_power = Utility.GetSafeComponent<Card>(defender_field.transform.GetChild(0).gameObject).POWER;
+        field_atk_attr = Utility.GetSafeComponent<Card>(attacker_field.transform.GetChild(0).gameObject).ATTRIBUTE;
+        field_def_attr = Utility.GetSafeComponent<Card>(defender_field.transform.GetChild(0).gameObject).ATTRIBUTE;
+        // 防御側のフィールドに出ているカードの属性=攻撃側のフィールドに出ているカードならば、防御クリティカル発生
+        if (field_def_attr.Equals(field_atk_attr)) {
+            Variables.def_critical = 0.5f;
         }
 
         */
-        
+
         // 実際のダメージ計算。プレイヤーと敵が持つ3属性の攻撃力・防御力はどこで保持する・・・？
         // Variables.damage = atk_power - (int)(def_power * Variables.def_down * Variables.def_critical);
-        yield return null;
+        yield return new WaitForSeconds(1.0f); // 1秒待つ
     }
 
     private IEnumerator RoundTomb() {
-        // HPが0になったカードを墓地に送る。フィールドにいるカード(攻撃、防御、イベント)が、墓地に行く可能性有
-        /* if (FieldのカードのHP == 0) {
-         *     field_defside.parent = tomb_defside;
-         * }
-         */
-        yield return null;
+        // 特殊・イベントカードを含めた、フィールドに出ているカードを、ターン交代直前に墓地に移動させる
+        // HPが0になったシールドは、そのまま残しておく
+
+        if (attacker_field.transform.childCount > 0) {
+            // 攻撃側と防御側のフィールド双方に
+            GameObject attacker_field_child = attacker_field.transform.GetChild(0).gameObject;
+            attacker_field_child.transform.parent = attacker_tomb.transform;
+        }
+        if (defender_field.transform.childCount > 0) {
+            GameObject defender_field_child = defender_field.transform.GetChild(0).gameObject;
+            defender_field_child.transform.parent = defender_tomb.transform;
+        }
+        // イベントエリア内のカード移動は、HandSet.csのメソッドevent_summonの実装ができてから。
+
+        yield return new WaitForSeconds(1.0f); // 1秒待つ
     }
 
     private IEnumerator RoundTurnChange() {
         tm.changeTurn();
         turn_total++;
-        attacker_name = players[tm.Turn].name; // 攻守交代
-        Debug.Log(attacker_name);
-        yield return null;
+        tmp_attacker_name = players[tm.Turn].name;
+        // 攻守交代のため、攻撃側と防御側のGameObjectをそれぞれ更新
+        attacker_deck = players[tm.Turn].transform.Find("Cards/Deck").gameObject;
+        attacker_hand = players[tm.Turn].transform.Find("Cards/Hand").gameObject;
+        attacker_field = players[tm.Turn].transform.Find("Cards/Field").gameObject;
+        attacker_tomb = players[tm.Turn].transform.Find("Cards/Tomb").gameObject;
+        defender_deck = players[tm.getNextTurn()].transform.Find("Cards/Deck").gameObject;
+        defender_hand = players[tm.getNextTurn()].transform.Find("Cards/Hand").gameObject;
+        defender_field = players[tm.getNextTurn()].transform.Find("Cards/Field").gameObject;
+        defender_tomb = players[tm.getNextTurn()].transform.Find("Cards/Tomb").gameObject;
+        Debug.Log(tmp_attacker_name);
+        yield return new WaitForSeconds(1.0f); // 1秒待つ
     }
 
-    private IEnumerator RoundSkip() {
-        // ゲーム画面でスキップボタンが押されたらここを実行
-        yield return null;
+    // モードごとに、攻撃側or防御側のカードを選べないようにする
+    void change_isSelectable(GameObject hand, int mode) {
+        switch (mode) {
+            case 0: // 全てfalse
+                foreach (Transform hand_child in hand.transform) {
+                    Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
+                    hand_child_card.ISSELECTABLE = false;
+                }
+                break;
+            case 1: // 特殊カードとイベントカード以外をfalse
+                foreach (Transform hand_child in hand.transform) {
+                    Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
+                    if (!hand_child_card.TYPE.Equals("EV") && !hand_child_card.TYPE.Equals("SP")) {
+                        hand_child_card.ISSELECTABLE = false;
+                    }
+                }
+                break;
+            case 2: // 攻撃カード以外をfalse
+                foreach (Transform hand_child in hand.transform) {
+                    Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
+                    if (!hand_child_card.TYPE.Equals("ATK")) {
+                        hand_child_card.ISSELECTABLE = false;
+                    }
+                }
+                break;
+            case 3: // 防御カード以外をfalse
+                foreach (Transform hand_child in hand.transform) {
+                    Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
+                    if (!hand_child_card.TYPE.Equals("DEF")) {
+                        hand_child_card.ISSELECTABLE = false;
+                    }
+                }
+                break;
+            default: // モードが範囲外なら何もしない
+                break;
+        }
+    }
+
+    // 各フェーズで、攻撃側or防御側がカードを出せるかどうかチェックしてcanSummonを更新する
+    void check_canSummon(GameObject hand, int phase) {
+        switch (phase) {
+            case 1: // 特殊カード・イベントカードを出すフェーズで攻撃側がカードを出せるかどうか
+                foreach (Transform hand_child in hand.transform) {
+                    Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
+                    if (hand_child_card.TYPE.Equals("EV") || hand_child_card.TYPE.Equals("SP")) {
+                        Variables.attacker_canSummon = true;
+                    }
+                }
+                break;
+            case 2: // 攻撃フェーズで攻撃側がカードを出せるかどうか
+                foreach (Transform hand_child in hand.transform) {
+                    Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
+                    if (!hand_child_card.TYPE.Equals("ATK")) {
+                        Variables.attacker_canSummon = true;
+                    }
+                }
+                break;
+            case 3: // 防御フェーズで防御側がカードを出せるかどうか
+                foreach (Transform hand_child in hand.transform) {
+                    Card hand_child_card = Utility.GetSafeComponent<Card>(hand_child.gameObject);
+                    if (!hand_child_card.TYPE.Equals("DEF")) {
+                        Variables.defender_canSummon = true;
+                    }
+                }
+                break;
+            default: // モードが範囲外なら何もしない
+                break;
+        }
+    }
+
+    // 各フェーズで、攻撃側or防御側がカードを手札からフィールドに出す
+    void summon_to_field(GameObject hand, int phase) {
+        switch (phase) {
+            case 1: // RoundSpEventのフェーズで、攻撃側がカードを出す
+                if (tmp_attacker_name.Equals("Player")) {
+                    string player_tapped_cardtype = Utility.GetSafeComponent<Card>(Variables.player_tapped_obj).TYPE;
+                    if (player_tapped_cardtype.Equals("EV")) {
+                        Utility.GetSafeComponent<HandSet>(attacker_hand).event_summon(Variables.player_tapped_obj);
+                    } else if (player_tapped_cardtype.Equals("SP")) {
+                        Utility.GetSafeComponent<HandSet>(attacker_hand).summon(Variables.player_tapped_obj);
+                    }
+                    // 操作系の変数の中身をリセット
+                    Variables.player_tapped_obj = null;
+                    Variables.player_isSkippable = false;
+                } else if (tmp_attacker_name.Equals("Enemy")) {
+                    string enemy_selected_cardtype = Utility.GetSafeComponent<Card>(Variables.enemy_selected_obj).TYPE;
+                    if (enemy_selected_cardtype.Equals("EV")) {
+                        Utility.GetSafeComponent<HandSet>(attacker_hand).event_summon(Variables.enemy_selected_obj);
+                    } else if (enemy_selected_cardtype.Equals("SP")) {
+                        Utility.GetSafeComponent<HandSet>(attacker_hand).summon(Variables.enemy_selected_obj);
+                    }
+                    // 操作系の変数の中身をリセット
+                    Variables.enemy_selected_obj = null;
+                }
+                Variables.attacker_canSummon = false;
+                break;
+            case 2: // RoundAttackのフェーズで、攻撃側がカードを出す
+                if (tmp_attacker_name.Equals("Player")) {
+                    string player_tapped_cardtype = Utility.GetSafeComponent<Card>(Variables.player_tapped_obj).TYPE;
+                    if (player_tapped_cardtype.Equals("ATK")) {
+                        Utility.GetSafeComponent<HandSet>(attacker_hand).summon(Variables.player_tapped_obj);
+                    }
+                    // 操作系の変数の中身をリセット
+                    Variables.player_tapped_obj = null;
+                    Variables.player_isSkippable = false;
+                } else if (tmp_attacker_name.Equals("Enemy")) {
+                    string enemy_selected_cardtype = Utility.GetSafeComponent<Card>(Variables.enemy_selected_obj).TYPE;
+                    if (enemy_selected_cardtype.Equals("ATK")) {
+                        Utility.GetSafeComponent<HandSet>(attacker_hand).summon(Variables.enemy_selected_obj);
+                    }
+                    // 操作系の変数の中身をリセット
+                    Variables.enemy_selected_obj = null;
+                }
+                Variables.attacker_canSummon = false;
+                break;
+            case 3: // RoundDefenseのフェーズで、防御側がカードを出す
+                if (tmp_attacker_name.Equals("Player")) {
+                    string enemy_selected_cardtype = Utility.GetSafeComponent<Card>(Variables.enemy_selected_obj).TYPE;
+                    if (enemy_selected_cardtype.Equals("DEF")) {
+                        Utility.GetSafeComponent<HandSet>(defender_hand).summon(Variables.enemy_selected_obj);
+                    }
+                    // 操作系の変数の中身をリセット
+                    Variables.enemy_selected_obj = null;
+                } else if (tmp_attacker_name.Equals("Enemy")) {
+                    string player_tapped_cardtype = Utility.GetSafeComponent<Card>(Variables.player_tapped_obj).TYPE;
+                    if (player_tapped_cardtype.Equals("DEF")) {
+                        Utility.GetSafeComponent<HandSet>(defender_hand).summon(Variables.player_tapped_obj);
+                    }
+                    // 操作系の変数の中身をリセット
+                    Variables.player_tapped_obj = null;
+                    Variables.player_isSkippable = false;
+                }
+                Variables.defender_canSummon = false;
+                break;
+        }
     }
 
     // 1試合が終わったかどうかを判定する
     bool isFinished() {
-        /* if (3枚のシールドのどこかから情報を抜き取られたら) {
+        /* if (3枚のシールドの総HPが0になったら || 攻撃側と防御側の双方に、出せる攻撃カードが無くなったら？) {
          *     return true;
          * }
          */

--- a/CardGame/Assets/Scripts/Scene/Main/HandSet.cs
+++ b/CardGame/Assets/Scripts/Scene/Main/HandSet.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
@@ -19,19 +20,26 @@ public class HandSet : MonoBehaviour {
         player_name = transform.parent.parent.name;
         count = transform.childCount;
         children = new GameObject[20];
-        sld = GameObject.Find("Player_Slider").GetComponent<Slider>();
+
+        if (player_name == "Player") {
+            sld = GameObject.Find("Player_Slider").GetComponent<Slider>();
+        }
     }
 	
 	// Update is called once per frame
 	void Update () {
         count = transform.childCount;
-        if (count < 5) {
-            sld.interactable = false;
-        }else {
-            sld.interactable = true;
+        if (player_name == "Player") {
+            if (count < 5) {
+                sld.interactable = false;
+            } else {
+                sld.interactable = true;
+            }
         }
         setCards();  //恐らく本当はupdateにあってはいけない関数。ゲームマネジャーがカードからドローした後に整列のために呼び出すべき
-        slide();
+        if (player_name == "Player") {
+            slide();
+        }
 	}
 
     //デッキ内のカードを正しい位置に移動
@@ -39,14 +47,19 @@ public class HandSet : MonoBehaviour {
         children = new GameObject[count];
 
         //スライダーのつまみを中央に戻す必要あり？(ゲームマネージャー内で使用する時にはコメントアウト外してください)
-
-        //sld.value = (float)0.5;
+        //if (player_name == "Player") {
+            //sld.value = (float)0.5;
+        //}
 
         if (count % 2 == 0) {  //偶数の時の挙動
             for (int i = 0; count > i; i++) {
                 children[i] = transform.GetChild(i).gameObject;
                 double x = -0.8 - 1.6 * (count / 2 - 1) + 1.6 * i;
-                children[i].transform.localPosition = new Vector3((float)x, -5, 0);
+                if (player_name == "Player") {
+                    children[i].transform.localPosition = new Vector3((float)x, -5, 0);
+                }else {
+                    children[i].transform.localPosition = new Vector3((float)x, 5, 0);
+                }
                 children[i].GetComponent<Card>().ISBACK = false;  //とりあえず表に
                 children[i].GetComponent<Card>().ISSELECTABLE = true;  //とりあえず選択可に(暫定なので後々消してゲームマネージャーでちゃんと管理してください)
 
@@ -55,7 +68,11 @@ public class HandSet : MonoBehaviour {
             for (int i = 0; count > i; i++) {
                 children[i] = transform.GetChild(i).gameObject;
                 double x = -1.6 * ((count - 1) / 2) + 1.6 * i;
-                children[i].transform.localPosition = new Vector3((float)x, -5, 0);
+                if (player_name == "Player") {
+                    children[i].transform.localPosition = new Vector3((float)x, -5, 0);
+                }else {
+                    children[i].transform.localPosition = new Vector3((float)x, 5, 0);
+                }
                 children[i].GetComponent<Card>().ISBACK = false;  //とりあえず表に
                 children[i].GetComponent<Card>().ISSELECTABLE = true;  //とりあえず選択可に(暫定なので後々消してゲームマネージャーでちゃんと管理してください)
             }
@@ -89,6 +106,23 @@ public class HandSet : MonoBehaviour {
     //イベポジに出す関数(GameObject引数？イベポジが詳細未定なので未作成)
     public void event_summon (GameObject card) {
 
+    }
+
+    //手札からその時出せるカードをランダムで選んで出す関数(Enemy専用)
+    public void random_summon() {
+        var canSummonCards = new List<GameObject>();
+        for (int i = 0; count > i; i++) {
+            if (children[i].GetComponent<Card>().ISSELECTABLE) {
+                canSummonCards.Add(children[i]);
+            }
+        }
+
+        //乱数生成
+        System.Random Random = new System.Random();
+        int RandomI = Random.Next(0,canSummonCards.Count);
+
+        //選んでいるだけ,summoやevent_summonで親子関係の変更はやってください
+        Variables.enemy_selected_obj = canSummonCards[RandomI];
     }
 
 }

--- a/CardGame/Assets/Scripts/Scene/Main/Shield.cs
+++ b/CardGame/Assets/Scripts/Scene/Main/Shield.cs
@@ -8,6 +8,7 @@ public class Shield : MonoBehaviour {
     [SerializeField]
     private string shield_attribute;
     private int shield_hp;
+    public string shield_parent;
 
     //スプライトとレンダラ
     private Sprite sp;
@@ -20,13 +21,25 @@ public class Shield : MonoBehaviour {
 	void Start () {
         if (shield_attribute == "C") {
             sp = Utility.GetSprite("Sprites","shield_C");
-            Text_hp = GameObject.Find("Player_shield_C").GetComponent<Text>();
+            if (shield_parent == "Player") {
+                Text_hp = GameObject.Find("Player_shield_C").GetComponent<Text>();
+            }else {
+                Text_hp = GameObject.Find("Enemy_shield_C").GetComponent<Text>();
+            }
         }else if(shield_attribute == "I") {
             sp = Utility.GetSprite("Sprites", "shield_I");
-            Text_hp = GameObject.Find("Player_shield_I").GetComponent<Text>();
+            if (shield_parent == "Player") {
+                Text_hp = GameObject.Find("Player_shield_I").GetComponent<Text>();
+            }else {
+                Text_hp = GameObject.Find("Enemy_shield_I").GetComponent<Text>();
+            }
         } else if(shield_attribute == "A") {
             sp = Utility.GetSprite("Sprites", "shield_A");
-            Text_hp = GameObject.Find("Player_shield_A").GetComponent<Text>();
+            if (shield_parent == "Player") {
+                Text_hp = GameObject.Find("Player_shield_A").GetComponent<Text>();
+            }else {
+                Text_hp = GameObject.Find("Enemy_shield_A").GetComponent<Text>();
+            }
         }
         sr = GetComponent<SpriteRenderer>();
         sr.sprite = sp;
@@ -53,5 +66,10 @@ public class Shield : MonoBehaviour {
     public int HP {
         set { shield_hp = value; }
         get { return shield_hp; }
+    }
+
+    public string PARENT {
+        set { shield_parent = value; }
+        get { return shield_parent; }
     }
 }

--- a/CardGame/Assets/Scripts/Scene/Main/ShieldManager.cs
+++ b/CardGame/Assets/Scripts/Scene/Main/ShieldManager.cs
@@ -12,21 +12,25 @@ public class ShieldManager : MonoBehaviour {
     private bool isCreated;
 
     //hpの更新もここから
-    private Text Player_hp;
+    private Text hp;
 
     // Use this for initialization
     void Start () {
         CreateShield();
 
-        Player_hp = GameObject.Find("Player_hp").GetComponent<Text>();
-        Player_hp.text = (shields[0].GetComponent<Shield>().HP
+        if (transform.parent.name == "Player") {
+            hp = GameObject.Find("Player_hp").GetComponent<Text>();
+        }else {
+            hp = GameObject.Find("Enemy_hp").GetComponent<Text>();
+        }
+        hp.text = (shields[0].GetComponent<Shield>().HP
                         + shields[1].GetComponent<Shield>().HP
                         + shields[2].GetComponent<Shield>().HP).ToString();
     }
 	
 	// Update is called once per frame
 	void Update () {
-        Player_hp.text = (shields[0].GetComponent<Shield>().HP
+        hp.text = (shields[0].GetComponent<Shield>().HP
                         + shields[1].GetComponent<Shield>().HP
                         + shields[2].GetComponent<Shield>().HP).ToString();
     }
@@ -65,6 +69,7 @@ public class ShieldManager : MonoBehaviour {
                     shield.ATTRIBUTE = "A";
                 }
                 shield.HP = 1000;  //後でゲーム開始前の入力に合わせられるようにしたい
+                shield.PARENT = transform.parent.name;
 
                 //座標指定
                 float x = 0;
@@ -75,7 +80,12 @@ public class ShieldManager : MonoBehaviour {
                 } else if (i == 2) {
                     x = (float)1.25;
                 }
-                float y = (float)-3.25;
+                float y = 0;
+                if (transform.parent.name == "Player") {
+                    y = (float)-3.25;
+                }else {
+                    y = (float)3.25;
+                }
                 shields[i].transform.localPosition = new Vector3(x, y, 0);
 
                 //親指定

--- a/CardGame/Assets/Scripts/Scene/Main/TombSet.cs
+++ b/CardGame/Assets/Scripts/Scene/Main/TombSet.cs
@@ -5,11 +5,13 @@ using UnityEngine;
 public class TombSet : MonoBehaviour {
 
     //メンバ変数
+    string player_name;
     int count;
     GameObject[] children;
 
     // Use this for initialization
     void Start () {
+        player_name = transform.parent.parent.name;
         count = transform.childCount;
     }
 
@@ -26,7 +28,11 @@ public class TombSet : MonoBehaviour {
             children = new GameObject[count];
             for (int i = 0; count > i; i++) {
                 children[i] = transform.GetChild(i).gameObject;
-                children[i].transform.localPosition = new Vector3(-3, (float)-2.5, 0);
+                if (player_name == "Player") {
+                    children[i].transform.localPosition = new Vector3(-3, (float)-2.5, 0);
+                }else {
+                    children[i].transform.localPosition = new Vector3(3, (float)2.5, 0);
+                }
                 children[i].GetComponent<Card>().ISSELECTABLE = false;  //選択不可に
             }
         }


### PR DESCRIPTION
・下記の動作実装の為、card.cs、shield.csに持ち主を示すメンバ変数追加
・DeckSet等の持ち主メンバ変数を用いて動作を小分けに
・何故かFieldSetとTombSetが外れてたのでアタッチ
・敵のカードを置く位置を調整
・UI系もとりあえず対称に
・その時出せるカードからランダムで出す動作(敵専用を実装)
・Tapの動作の内、敵カードに起こるべきでない動作をプレイヤーカードのみに起きるように

(追記)
・現状、自カードクリック⇒敵カードクリックで敵のカードがプレイヤーのフィールドに出されてしまう状態を確認（多分GMでカードのisSelectableをちゃんと調整すれば解決するはず）
・アタッチが勝手に外れてしまうことがあるからコンフリ解消時注意してください